### PR TITLE
feat(math): add fixed-size Matrix implementation with common operations & utilities

### DIFF
--- a/include/cobalt/math/linear_algebra/linear_algebra.hpp
+++ b/include/cobalt/math/linear_algebra/linear_algebra.hpp
@@ -6,3 +6,6 @@
 #include "vector/vector.hpp"        // Core vector definition
 #include "vector/vector_ops.hpp"    // -- Vector arithmetic & math operation defintions
 #include "vector/vector_util.hpp"   // -- Vector utility tool & algorithm defintions
+
+// ----- Matrix -----
+#include "matrix/matrix.hpp"        // Core matrix definition

--- a/include/cobalt/math/linear_algebra/matrix/matrix.hpp
+++ b/include/cobalt/math/linear_algebra/matrix/matrix.hpp
@@ -1,0 +1,207 @@
+#pragma once
+
+#include <stdint.h>
+#include <cmath>
+#include <array>
+#include <string>
+
+namespace cobalt::math::linear_algebra {
+
+constexpr uint8_t MATRIX_MAX_ROW_SIZE = 12;
+constexpr uint8_t MATRIX_MAX_COL_SIZE = 12;
+
+constexpr float   MATRIX_EQUAL_THRESHOLD = 1e-5;
+constexpr float   MATRIX_ZERO_THRESHOLD = 1e-12;
+
+constexpr uint8_t MATRIX_DEFAULT_PRECISION = 3;
+
+// --------------------------------------
+//          NxM - Matrix    
+// --------------------------------------
+
+/**
+ *  @brief Fixed-size matrix.
+ *  @tparam R Row count of the matrix.
+ *  @tparam C Column count of the matrix.
+ *  @tparam T Element type (default float).
+ */
+template<uint8_t R, uint8_t C, typename T = float>
+struct Matrix {
+    static_assert(R > 0                     , "[MATRIX Error] : Matrix rows must be positive.");
+    static_assert(C > 0                     , "[MATRIX Error] : Matrix columns must be positive");
+    static_assert(R <= MATRIX_MAX_ROW_SIZE  , "[MATRIX Error] : Matrix rows exceeds maximum size.");
+    static_assert(C <= MATRIX_MAX_COL_SIZE  , "[MATRIX Error] : Matrix columns exceeds maximum size.");
+
+    private:
+        std::array<T, R*C> data_{};
+
+    public:
+        // ---------------- Constructors ----------------
+        /**
+         *  @brief Construct a zero-initialized matrix.
+         */
+        constexpr Matrix() noexcept : data_{} {}
+
+        /**
+         *  @brief Construct a matrix from an 2d initializer list.
+         *  @param list2d 2D-Initializer list to copy values from.
+         */ 
+        constexpr Matrix(std::initializer_list<std::initializer_list<T>> list2d) noexcept {
+            uint8_t i = 0, j = 0;
+
+            for(std::initializer_list<T> list : list2d) {
+                j = 0;
+                for(T val : list) {
+                    if(i < R && j < C) { data_[i*C + j] = val; }
+                    j++;
+                }
+
+                for(; j < C; j++) { data_[i*C + j] = static_cast<T>(0); }
+
+                i++;
+                if(i >= R) break;
+            }
+
+            for(; i < R; i++) { 
+                for(; j < C; j++) { data_[i*C + j] = static_cast<T>(0); }
+            }
+        }
+
+        // ---------------- Static Factories ----------------
+
+        /**
+         *  @brief Construct a zero matrix.
+         */
+        static constexpr Matrix zero() noexcept { return Matrix(); }
+
+        /**
+         *  @brief Construct an identity matrix.
+         */
+        static constexpr Matrix eye() noexcept { 
+            Matrix<R, C, T> out{};
+            uint8_t d = (R <= C) ?R :C;
+
+            for(uint8_t i = 0; i < d; i++) {
+                out(i, i) = static_cast<T>(1);
+            }
+
+            return out;
+        }
+        
+        // ---------------- Getters ----------------
+        /**
+         *  @brief Return the row number of the vector.
+         */
+        constexpr uint8_t rows() const { return R; }
+
+        /**
+         *  @brief Return the column number of the vector.
+         */
+        constexpr uint8_t cols() const { return C; }
+
+        // ---------------- Element Accessors ----------------
+            /**
+             *  @brief Access element at the given row/column.
+             *  @param r Row of the accessed element.
+             *  @param c Column of the accessed element.
+             *  @return Reference to element.
+             */
+            constexpr T &operator()(uint8_t r, uint8_t c) { if(r >= R) { r = R-1; } if(c >= C) { c = C-1; } return data_[r*C + c]; }
+
+            /**
+             *  @brief Const access to element at the given row/column.
+             *  @param r Row of the accessed element.
+             *  @param c Column of the accessed element.
+             *  @return Const reference to element.
+             */
+            const T &operator()(uint8_t r, uint8_t c) const { if(r >= R) { r = R-1; } if(c >= C) { c = C-1; } return data_[r*C + c]; }
+        
+        // ---------------- Arithmetic Overloads ----------------
+        /**
+         *  @brief Add another matrix to this matrix.
+         */
+        constexpr Matrix &operator+=(const Matrix &rhs) {
+            for(uint8_t i = 0; i < R; i++) { 
+                for(uint8_t j = 0; j < C; j++) {
+                    data_[i*C + j] += rhs.data_[i*C + j]; 
+                }
+            }
+            return *this;
+        }
+
+        /**
+         *  @brief Subtract another matrix from this matrix.
+         */
+        constexpr Matrix &operator-=(const Matrix &rhs) {
+            for(uint8_t i = 0; i < R; i++) { 
+                for(uint8_t j = 0; j < C; j++) {
+                    data_[i*C + j] -= rhs.data_[i*C + j]; 
+                }
+            }
+            return *this;
+        }
+
+        /**
+         *  @brief Right-multiply another matrix(CxL) to this matrix(RxC).
+         *  @return (RxL) right-multiplied matrix
+         */
+        template<uint8_t L>
+            constexpr Matrix<R, L> &operator*=(const Matrix<C, L, T> &rhs) {
+                Matrix<R, L, T> output{};
+
+                for(uint8_t i = 0; i < R; i++) {
+                    for(uint8_t j = 0; j < L; j++) {
+                        output(i, j) = static_cast<T>(0);
+
+                        for(uint8_t k = 0; k < C; k++) {
+                            output(i, j) += data_[i*C + k] * rhs(k, j);
+                        }
+                    }
+                }
+
+                *this = output;
+
+                return *this;
+            }
+
+        /**
+         *  @brief Scalar multiplication of this matrix
+         */
+        constexpr Matrix &operator*=(float c) {
+            for(uint8_t i = 0; i < R; i++) {
+                for(uint8_t j = 0; j < C; j++) {
+                    data_[i*C + j] *= c;
+                }
+            }
+
+            return *this;
+        }
+
+        /**
+         *  @brief Scalar divison of this matrix
+         */
+        constexpr Matrix &operator/=(float c) {
+            for(uint8_t i = 0; i < R; i++) {
+                for(uint8_t j = 0; j < C; j++) {
+                    data_[i*C + j] /= c;
+                }
+            }
+
+            return *this;
+        }
+
+        /**
+         *  @brief Element wise negative to this matrix
+         */
+        constexpr Matrix &operator-() {
+            for(uint8_t i = 0; i < R; i++) {
+                for(uint8_t j = 0; j < C; j++) {
+                    data_[i*C + j] *= -1.0f;
+                }
+            }
+
+            return *this;
+        }
+};
+
+} // cobalt::math::linear_algebra

--- a/include/cobalt/math/linear_algebra/matrix/matrix.hpp
+++ b/include/cobalt/math/linear_algebra/matrix/matrix.hpp
@@ -5,15 +5,18 @@
 #include <array>
 #include <string>
 
+#include "../vector/vector.hpp"
+
 namespace cobalt::math::linear_algebra {
 
 constexpr uint8_t MATRIX_MAX_ROW_SIZE = 12;
 constexpr uint8_t MATRIX_MAX_COL_SIZE = 12;
 
-constexpr float   MATRIX_EQUAL_THRESHOLD = 1e-5;
+constexpr float   MATRIX_EQUAL_THRESHOLD = 1e-6;
 constexpr float   MATRIX_ZERO_THRESHOLD = 1e-12;
 
 constexpr uint8_t MATRIX_DEFAULT_PRECISION = 3;
+constexpr uint8_t MATRIX_DEFAULT_SVD_ITERATIONS = 100;
 
 // --------------------------------------
 //          NxM - Matrix    
@@ -87,6 +90,36 @@ struct Matrix {
 
             return out;
         }
+
+        /**
+         *  @brief Convert a vector into a diagonal matrix
+         * 
+         *  Puts the vector elements along the diagonal of a matrix. If all the diagonals are not filled up, they are set to zero.
+         * 
+         *  @tparam R Diagonal matrix row count
+         *  @tparam C Diagonal matrix column count
+         *  @tparam N Vector size
+         *  @tparam T Vector/Matrix element type
+         *  @param d Vector with the diagonal elements
+         * 
+         *  @note The output matrix should, at the minimum, be able to contain the vector diagonals. `N <= R` and `N <= C`.
+         * 
+         */
+        template<uint8_t N>
+            static constexpr Matrix<R, C, T> diagonal(const Vector<N, T> &d) {
+                static_assert(R >= N, "[MATRIX Error] : Matrix row count is too small to contain the diagonal vector.");
+                static_assert(C >= N, "[MATRIX Error] : Matrix column count is too small to contain the diagonal vector.");
+
+                Matrix<R, C, T> output;
+
+                uint8_t minLength = (R < C) ?R :C;
+
+                for(uint8_t i = 0; i < minLength; i++) {
+                    output(i,i) = (i < N) ?d[i] :static_cast<T>(0);
+                }
+
+                return output;
+            }
         
         // ---------------- Getters ----------------
         /**
@@ -202,6 +235,14 @@ struct Matrix {
 
             return *this;
         }
+
+        // ------------ Member Functions  ------------
+        template<uint8_t N, uint8_t M>
+            constexpr inline Matrix<N, M, T> block(uint8_t r0 = 0, uint8_t c0 = 0) const;
+
+        // ---------------- Utility  ----------------
+        
+        std::string toString(uint8_t percision = MATRIX_DEFAULT_PRECISION) const;
 };
 
 } // cobalt::math::linear_algebra

--- a/include/cobalt/math/linear_algebra/matrix/matrix.hpp
+++ b/include/cobalt/math/linear_algebra/matrix/matrix.hpp
@@ -24,19 +24,19 @@ constexpr uint8_t MATRIX_DEFAULT_SVD_ITERATIONS = 100;
 
 /**
  *  @brief Fixed-size matrix.
- *  @tparam R Row count of the matrix.
- *  @tparam C Column count of the matrix.
+ *  @tparam N Row count of the matrix.
+ *  @tparam M Column count of the matrix.
  *  @tparam T Element type (default float).
  */
-template<uint8_t R, uint8_t C, typename T = float>
+template<uint8_t N, uint8_t M, typename T = float>
 struct Matrix {
-    static_assert(R > 0                     , "[MATRIX Error] : Matrix rows must be positive.");
-    static_assert(C > 0                     , "[MATRIX Error] : Matrix columns must be positive");
-    static_assert(R <= MATRIX_MAX_ROW_SIZE  , "[MATRIX Error] : Matrix rows exceeds maximum size.");
-    static_assert(C <= MATRIX_MAX_COL_SIZE  , "[MATRIX Error] : Matrix columns exceeds maximum size.");
+    static_assert(N > 0                     , "[MATRIX Error] : Matrix rows must be positive.");
+    static_assert(M > 0                     , "[MATRIX Error] : Matrix columns must be positive");
+    static_assert(N <= MATRIX_MAX_ROW_SIZE  , "[MATRIX Error] : Matrix rows exceeds maximum size.");
+    static_assert(M <= MATRIX_MAX_COL_SIZE  , "[MATRIX Error] : Matrix columns exceeds maximum size.");
 
     private:
-        std::array<T, R*C> data_{};
+        std::array<T, N*M> data_{};
 
     public:
         // ---------------- Constructors ----------------
@@ -55,18 +55,18 @@ struct Matrix {
             for(std::initializer_list<T> list : list2d) {
                 j = 0;
                 for(T val : list) {
-                    if(i < R && j < C) { data_[i*C + j] = val; }
+                    if(i < N && j < M) { data_[i*M + j] = val; }
                     j++;
                 }
 
-                for(; j < C; j++) { data_[i*C + j] = static_cast<T>(0); }
+                for(; j < M; j++) { data_[i*M + j] = static_cast<T>(0); }
 
                 i++;
-                if(i >= R) break;
+                if(i >= N) break;
             }
 
-            for(; i < R; i++) { 
-                for(; j < C; j++) { data_[i*C + j] = static_cast<T>(0); }
+            for(; i < N; i++) { 
+                for(; j < M; j++) { data_[i*M + j] = static_cast<T>(0); }
             }
         }
 
@@ -81,8 +81,8 @@ struct Matrix {
          *  @brief Construct an identity matrix.
          */
         static constexpr Matrix eye() noexcept { 
-            Matrix<R, C, T> out{};
-            uint8_t d = (R <= C) ?R :C;
+            Matrix<N, M, T> out{};
+            uint8_t d = (N <= M) ?N :M;
 
             for(uint8_t i = 0; i < d; i++) {
                 out(i, i) = static_cast<T>(1);
@@ -96,26 +96,26 @@ struct Matrix {
          * 
          *  Puts the vector elements along the diagonal of a matrix. If all the diagonals are not filled up, they are set to zero.
          * 
-         *  @tparam R Diagonal matrix row count
-         *  @tparam C Diagonal matrix column count
-         *  @tparam N Vector size
+         *  @tparam N Diagonal matrix row count
+         *  @tparam M Diagonal matrix column count
+         *  @tparam K Vector size
          *  @tparam T Vector/Matrix element type
-         *  @param d Vector with the diagonal elements
+         *  @param  d Vector with the diagonal elements
          * 
-         *  @note The output matrix should, at the minimum, be able to contain the vector diagonals. `N <= R` and `N <= C`.
+         *  @note The output matrix should, at the minimum, be able to contain the vector diagonals. `K <= N` and `K <= M`.
          * 
          */
-        template<uint8_t N>
-            static constexpr Matrix<R, C, T> diagonal(const Vector<N, T> &d) {
-                static_assert(R >= N, "[MATRIX Error] : Matrix row count is too small to contain the diagonal vector.");
-                static_assert(C >= N, "[MATRIX Error] : Matrix column count is too small to contain the diagonal vector.");
+        template<uint8_t K>
+            static constexpr Matrix<N, M, T> diagonal(const Vector<K, T> &d) {
+                static_assert(N >= K, "[MATRIX Error] : Matrix row count is too small to contain the diagonal vector.");
+                static_assert(M >= K, "[MATRIX Error] : Matrix column count is too small to contain the diagonal vector.");
 
-                Matrix<R, C, T> output;
+                Matrix<N, M, T> output;
 
-                uint8_t minLength = (R < C) ?R :C;
+                uint8_t minLength = (N < M) ?N :M;
 
                 for(uint8_t i = 0; i < minLength; i++) {
-                    output(i,i) = (i < N) ?d[i] :static_cast<T>(0);
+                    output(i,i) = (i < K) ?d[i] :static_cast<T>(0);
                 }
 
                 return output;
@@ -125,12 +125,12 @@ struct Matrix {
         /**
          *  @brief Return the row number of the vector.
          */
-        constexpr uint8_t rows() const { return R; }
+        constexpr uint8_t rows() const { return N; }
 
         /**
          *  @brief Return the column number of the vector.
          */
-        constexpr uint8_t cols() const { return C; }
+        constexpr uint8_t cols() const { return M; }
 
         // ---------------- Element Accessors ----------------
             /**
@@ -139,7 +139,7 @@ struct Matrix {
              *  @param c Column of the accessed element.
              *  @return Reference to element.
              */
-            constexpr T &operator()(uint8_t r, uint8_t c) { if(r >= R) { r = R-1; } if(c >= C) { c = C-1; } return data_[r*C + c]; }
+            constexpr T &operator()(uint8_t r, uint8_t c) { if(r >= N) { r = N-1; } if(c >= M) { c = M-1; } return data_[r*M + c]; }
 
             /**
              *  @brief Const access to element at the given row/column.
@@ -147,16 +147,16 @@ struct Matrix {
              *  @param c Column of the accessed element.
              *  @return Const reference to element.
              */
-            const T &operator()(uint8_t r, uint8_t c) const { if(r >= R) { r = R-1; } if(c >= C) { c = C-1; } return data_[r*C + c]; }
+            const T &operator()(uint8_t r, uint8_t c) const { if(r >= N) { r = N-1; } if(c >= M) { c = M-1; } return data_[r*M + c]; }
         
         // ---------------- Arithmetic Overloads ----------------
         /**
          *  @brief Add another matrix to this matrix.
          */
         constexpr Matrix &operator+=(const Matrix &rhs) {
-            for(uint8_t i = 0; i < R; i++) { 
-                for(uint8_t j = 0; j < C; j++) {
-                    data_[i*C + j] += rhs.data_[i*C + j]; 
+            for(uint8_t i = 0; i < N; i++) { 
+                for(uint8_t j = 0; j < M; j++) {
+                    data_[i*M + j] += rhs.data_[i*M + j]; 
                 }
             }
             return *this;
@@ -166,28 +166,28 @@ struct Matrix {
          *  @brief Subtract another matrix from this matrix.
          */
         constexpr Matrix &operator-=(const Matrix &rhs) {
-            for(uint8_t i = 0; i < R; i++) { 
-                for(uint8_t j = 0; j < C; j++) {
-                    data_[i*C + j] -= rhs.data_[i*C + j]; 
+            for(uint8_t i = 0; i < N; i++) { 
+                for(uint8_t j = 0; j < M; j++) {
+                    data_[i*M + j] -= rhs.data_[i*M + j]; 
                 }
             }
             return *this;
         }
 
         /**
-         *  @brief Right-multiply another matrix(CxL) to this matrix(RxC).
-         *  @return (RxL) right-multiplied matrix
+         *  @brief Right-multiply another matrix(MxL) to this matrix(NxM).
+         *  @return (NxL) right-multiplied matrix
          */
         template<uint8_t L>
-            constexpr Matrix<R, L> &operator*=(const Matrix<C, L, T> &rhs) {
-                Matrix<R, L, T> output{};
+            constexpr Matrix<N, L> &operator*=(const Matrix<M, L, T> &rhs) {
+                Matrix<N, L, T> output{};
 
-                for(uint8_t i = 0; i < R; i++) {
+                for(uint8_t i = 0; i < N; i++) {
                     for(uint8_t j = 0; j < L; j++) {
                         output(i, j) = static_cast<T>(0);
 
-                        for(uint8_t k = 0; k < C; k++) {
-                            output(i, j) += data_[i*C + k] * rhs(k, j);
+                        for(uint8_t k = 0; k < M; k++) {
+                            output(i, j) += data_[i*M + k] * rhs(k, j);
                         }
                     }
                 }
@@ -201,9 +201,9 @@ struct Matrix {
          *  @brief Scalar multiplication of this matrix
          */
         constexpr Matrix &operator*=(float c) {
-            for(uint8_t i = 0; i < R; i++) {
-                for(uint8_t j = 0; j < C; j++) {
-                    data_[i*C + j] *= c;
+            for(uint8_t i = 0; i < N; i++) {
+                for(uint8_t j = 0; j < M; j++) {
+                    data_[i*M + j] *= c;
                 }
             }
 
@@ -214,9 +214,9 @@ struct Matrix {
          *  @brief Scalar divison of this matrix
          */
         constexpr Matrix &operator/=(float c) {
-            for(uint8_t i = 0; i < R; i++) {
-                for(uint8_t j = 0; j < C; j++) {
-                    data_[i*C + j] /= c;
+            for(uint8_t i = 0; i < N; i++) {
+                for(uint8_t j = 0; j < M; j++) {
+                    data_[i*M + j] /= c;
                 }
             }
 
@@ -227,9 +227,9 @@ struct Matrix {
          *  @brief Element wise negative to this matrix
          */
         constexpr Matrix &operator-() {
-            for(uint8_t i = 0; i < R; i++) {
-                for(uint8_t j = 0; j < C; j++) {
-                    data_[i*C + j] *= -1.0f;
+            for(uint8_t i = 0; i < N; i++) {
+                for(uint8_t j = 0; j < M; j++) {
+                    data_[i*M + j] *= -1.0f;
                 }
             }
 
@@ -237,11 +237,10 @@ struct Matrix {
         }
 
         // ------------ Member Functions  ------------
-        template<uint8_t N, uint8_t M>
-            constexpr inline Matrix<N, M, T> block(uint8_t r0 = 0, uint8_t c0 = 0) const;
+        template<uint8_t R, uint8_t C>
+            constexpr inline Matrix<R, C, T> block(uint8_t r0 = 0, uint8_t c0 = 0) const;
 
         // ---------------- Utility  ----------------
-        
         std::string toString(uint8_t percision = MATRIX_DEFAULT_PRECISION) const;
 };
 

--- a/include/cobalt/math/linear_algebra/matrix/matrix_ops.hpp
+++ b/include/cobalt/math/linear_algebra/matrix/matrix_ops.hpp
@@ -9,26 +9,26 @@ namespace cobalt::math::linear_algebra {
 
 // ---------------- Member Functions ----------------
 /**
- *  @brief Get a NxM matrix block out of a RxC matrix.
+ *  @brief Get a RxC matrix block out of a NxM matrix.
  *  
- *  Extracts a NxM matrix from the elements `(r0, c0)` --> `(r0 + N, c0 + M)`.
+ *  Extracts a RxC matrix from the elements `(r0, c0)` --> `(r0 + R, c0 + C)`.
  * 
  * 
- *  @tparam N Row count of the output matrix.
- *  @tparam M Column count of the output matrix.
+ *  @tparam R Row count of the output matrix.
+ *  @tparam C Column count of the output matrix.
  *  @param r0 (optional) Starting row of the block
  *  @param c0 (optional) Starting column of the block
  * 
  *  @note If the original matrix isn't defined inside the output block the missing entried are set to zero.
  */
-template<uint8_t R, uint8_t C, typename T>
-template<uint8_t N, uint8_t M>
-    constexpr inline Matrix<N, M, T> Matrix<R, C, T>::block(uint8_t r0, uint8_t c0) const {
-        Matrix<N, M, T> output = Matrix<N, M, T>::zero();
+template<uint8_t N, uint8_t M, typename T>
+template<uint8_t R, uint8_t C>
+    constexpr inline Matrix<R, C, T> Matrix<N, M, T>::block(uint8_t r0, uint8_t c0) const {
+        Matrix<R, C, T> output = Matrix<R, C, T>::zero();
 
-        for(uint8_t i = 0; i < N; i++) {
-            for(uint8_t j = 0; j < M; j++) {
-                output(i, j) = data_[(i+r0)*C + (j+c0)];
+        for(uint8_t i = 0; i < R; i++) {
+            for(uint8_t j = 0; j < C; j++) {
+                output(i, j) = data_[(i+r0)*M + (j+c0)];
             }
         }
 
@@ -39,42 +39,42 @@ template<uint8_t N, uint8_t M>
 /**
  *  @brief Matrix addition.
  */
-template<uint8_t R, uint8_t C, typename T = float>
-    constexpr inline Matrix<R, C, T> operator+(Matrix<R, C, T> lhs, const Matrix<R, C, T> &rhs) { lhs += rhs; return lhs; }
+template<uint8_t N, uint8_t M, typename T = float>
+    constexpr inline Matrix<N, M, T> operator+(Matrix<N, M, T> lhs, const Matrix<N, M, T> &rhs) { lhs += rhs; return lhs; }
 
 /**
  *  @brief Matrix subtraction.
  */
-template<uint8_t R, uint8_t C, typename T = float>
-    constexpr inline Matrix<R, C, T> operator-(Matrix<R, C, T> lhs, const Matrix<R, C, T> &rhs) { lhs -= rhs; return lhs; }
+template<uint8_t N, uint8_t M, typename T = float>
+    constexpr inline Matrix<N, M, T> operator-(Matrix<N, M, T> lhs, const Matrix<N, M, T> &rhs) { lhs -= rhs; return lhs; }
 
 /**
  *  @brief Scalar matrix multiplication.
  */
-template<uint8_t R, uint8_t C, typename T = float>
-    constexpr inline Matrix<R, C, T> operator*(Matrix<R, C, T> lhs, float c) { lhs *= c; return lhs; }
+template<uint8_t N, uint8_t M, typename T = float>
+    constexpr inline Matrix<N, M, T> operator*(Matrix<N, M, T> lhs, float c) { lhs *= c; return lhs; }
 
 /**
  *  @brief Scalar matrix multiplication.
  */
-template<uint8_t R, uint8_t C, typename T = float>
-    constexpr inline Matrix<R, C, T> operator*(float c, Matrix<R, C, T> lhs) { lhs *= c; return lhs; }
+template<uint8_t N, uint8_t M, typename T = float>
+    constexpr inline Matrix<N, M, T> operator*(float c, Matrix<N, M, T> lhs) { lhs *= c; return lhs; }
 
 /**
  *  @brief Matrix multiplication.
  */
-template<uint8_t R, uint8_t C, uint8_t K, typename T = float>
-    constexpr inline Matrix<R, K, T> operator*(Matrix<R, C, T> lhs, const Matrix<C, K, T> &rhs) { lhs *= rhs; return lhs; }
+template<uint8_t N, uint8_t M, uint8_t K, typename T = float>
+    constexpr inline Matrix<N, K, T> operator*(Matrix<N, M, T> lhs, const Matrix<M, K, T> &rhs) { lhs *= rhs; return lhs; }
 
 /**
  *  @brief Vector right-multiplication.
  */
-template<uint8_t R, uint8_t C, typename T = float>
-    constexpr inline Vector<R, T> operator*(const Matrix<R, C, T> &A, const Vector<C, T> &v) {
-        Vector<R, T> output{};
-        for(uint8_t i = 0; i < R; i++) {
+template<uint8_t N, uint8_t M, typename T = float>
+    constexpr inline Vector<N, T> operator*(const Matrix<N, M, T> &A, const Vector<M, T> &v) {
+        Vector<N, T> output{};
+        for(uint8_t i = 0; i < N; i++) {
             output[i] = static_cast<T>(0);
-            for(uint8_t j = 0; j < C; j++) {
+            for(uint8_t j = 0; j < M; j++) {
                 output[i] += v[j]*A(i, j);
             }
         }
@@ -84,16 +84,16 @@ template<uint8_t R, uint8_t C, typename T = float>
 /**
  *  @brief Scalar matrix divison.
  */
-template<uint8_t R, uint8_t C, typename T = float>
-    constexpr inline Matrix<R, C, T> operator/(Matrix<R, C, T> lhs, float c) { lhs /= c; return lhs; }
+template<uint8_t N, uint8_t M, typename T = float>
+    constexpr inline Matrix<N, M, T> operator/(Matrix<N, M, T> lhs, float c) { lhs /= c; return lhs; }
 
 /**
  *  @brief Matrix equality.
  */
-template<uint8_t R, uint8_t C, typename T = float>
-    constexpr inline bool operator==(const Matrix<R, C, T> &lhs, const Matrix<R, C, T> &rhs) { 
-        for(uint8_t i = 0; i < R; i++) {
-            for(uint8_t j = 0; j < C; j++) {
+template<uint8_t N, uint8_t M, typename T = float>
+    constexpr inline bool operator==(const Matrix<N, M, T> &lhs, const Matrix<N, M, T> &rhs) { 
+        for(uint8_t i = 0; i < N; i++) {
+            for(uint8_t j = 0; j < M; j++) {
                 if(std::abs(lhs(i, j) - rhs(i, j)) > static_cast<T>(MATRIX_EQUAL_THRESHOLD)) return false;
             }
         }
@@ -104,12 +104,12 @@ template<uint8_t R, uint8_t C, typename T = float>
 /**
  *  @brief Matrix inequality.
  */
-template<uint8_t R, uint8_t C, typename T = float>
-    constexpr inline bool operator!=(const Matrix<R, C, T> &lhs, const Matrix<R, C, T> &rhs) { return (!(lhs == rhs)); }
+template<uint8_t N, uint8_t M, typename T = float>
+    constexpr inline bool operator!=(const Matrix<N, M, T> &lhs, const Matrix<N, M, T> &rhs) { return (!(lhs == rhs)); }
 
 // ---------------- Non-member Functions ----------------
 /**
- *  @brief Determinant of a matrix
+ *  @brief Compute determinant of a matrix(NxN)
  *  @param A Matrix to get determinant of
  */
 template<uint8_t N, typename T = float>
@@ -161,15 +161,15 @@ template<uint8_t N, typename T = float>
     }
 
 /**
- *  @brief Matrix transposition
+ *  @brief Compute transpose of a matrix(NxN)
  *  @param A Matrix to transpose
  */
-template<uint8_t R, uint8_t C, typename T = float>
-    constexpr inline Matrix<C, R, T> transpose(const Matrix<R, C, T> &A) {
-        Matrix<C, R, T> output{};
+template<uint8_t N, uint8_t M, typename T = float>
+    constexpr inline Matrix<M, N, T> transpose(const Matrix<N, M, T> &A) {
+        Matrix<M, N, T> output{};
 
-        for(uint8_t i = 0; i < C; i++) {
-            for(uint8_t j = 0; j < R; j++) {
+        for(uint8_t i = 0; i < M; i++) {
+            for(uint8_t j = 0; j < N; j++) {
                 output(i, j) = A(j, i);
             }
         }
@@ -180,7 +180,9 @@ template<uint8_t R, uint8_t C, typename T = float>
 /**
  *  @brief Compute inverse of a matrix
  *  @param A Matrix to invert
- *  @param Ainv Inverted Matrix
+ *  @param Ainv Inverted output Matrix
+ *  @return `true` if inversion succeeds, `false` if A is signular.
+ *  @note Return value should not be ignored and handled properly if A is singular
  */
 template<uint8_t N, typename T = float>
     [[nodiscard]] constexpr inline bool inv(const Matrix<N, N, T> &A, Matrix<N, N, T> &Ainv) {
@@ -245,15 +247,15 @@ template<uint8_t N, typename T = float>
  *  @brief Compute rank of matrix
  *  @param A Matrix to compute rank of 
  */
-template<uint8_t R, uint8_t C, typename T = float>
-    constexpr inline uint8_t rank(const Matrix<R, C, T> &A) {
-        Matrix<R, C> Q;
+template<uint8_t N, uint8_t M, typename T = float>
+    constexpr inline uint8_t rank(const Matrix<N, M, T> &A) {
+        Matrix<N, M> Q;
 
-        if(gramSchmidt(A, Q)) { return R; } // Full rank
+        if(gramSchmidt(A, Q)) { return N; } // Full rank
 
-        uint8_t rankNum = R;
-        for(uint8_t j = 0; j < C; j++) {
-            Vector<C, T> colVec = toVector(Q, j);
+        uint8_t rankNum = N;
+        for(uint8_t j = 0; j < M; j++) {
+            Vector<M, T> colVec = toVector(Q, j);
 
             if(norm(colVec) < MATRIX_ZERO_THRESHOLD) { rankNum--; }
         }
@@ -265,11 +267,11 @@ template<uint8_t R, uint8_t C, typename T = float>
  *  @brief Compute matrix trace
  *  @param A Matrix to compute trace of 
  */
-template<uint8_t R, uint8_t C, typename T = float>
-    constexpr inline T trace(const Matrix<R, C, T> &A) {
+template<uint8_t N, uint8_t M, typename T = float>
+    constexpr inline T trace(const Matrix<N, M, T> &A) {
         T output = static_cast<T>(0);
 
-        for(uint8_t i = 0; i < C; i++) {
+        for(uint8_t i = 0; i < M; i++) {
             output += A(i, i);
         }
         
@@ -280,11 +282,11 @@ template<uint8_t R, uint8_t C, typename T = float>
  *  @brief Compute matrix trace product/geometric trace/diagonal product
  *  @param A Matrix to compute trace product of 
  */
-template<uint8_t R, uint8_t C, typename T = float>
-    constexpr inline T traceProduct(const Matrix<R, C, T> &A) {
+template<uint8_t N, uint8_t M, typename T = float>
+    constexpr inline T traceProduct(const Matrix<N, M, T> &A) {
         T output = static_cast<T>(1);
 
-        for(uint8_t i = 0; i < C; i++) {
+        for(uint8_t i = 0; i < M; i++) {
             output *= A(i, i);
         }
         

--- a/include/cobalt/math/linear_algebra/matrix/matrix_ops.hpp
+++ b/include/cobalt/math/linear_algebra/matrix/matrix_ops.hpp
@@ -1,0 +1,286 @@
+#pragma once
+
+#include "matrix.hpp"
+#include "matrix_util.hpp"
+
+#include "../vector/vector.hpp"
+
+namespace cobalt::math::linear_algebra {
+
+// ---------------- Non-member Arithmetic Overloads ----------------
+/**
+ *  @brief Matrix addition.
+ */
+template<uint8_t R, uint8_t C, typename T = float>
+    constexpr inline Matrix<R, C, T> operator+(Matrix<R, C, T> lhs, const Matrix<R, C, T> &rhs) { lhs += rhs; return lhs; }
+
+/**
+ *  @brief Matrix subtraction.
+ */
+template<uint8_t R, uint8_t C, typename T = float>
+    constexpr inline Matrix<R, C, T> operator-(Matrix<R, C, T> lhs, const Matrix<R, C, T> &rhs) { lhs -= rhs; return lhs; }
+
+/**
+ *  @brief Scalar matrix multiplication.
+ */
+template<uint8_t R, uint8_t C, typename T = float>
+    constexpr inline Matrix<R, C, T> operator*(Matrix<R, C, T> lhs, float c) { lhs *= c; return lhs; }
+
+/**
+ *  @brief Scalar matrix multiplication.
+ */
+template<uint8_t R, uint8_t C, typename T = float>
+    constexpr inline Matrix<R, C, T> operator*(float c, Matrix<R, C, T> lhs) { lhs *= c; return lhs; }
+
+/**
+ *  @brief Matrix multiplication.
+ */
+template<uint8_t R, uint8_t C, uint8_t K, typename T = float>
+    constexpr inline Matrix<R, K, T> operator*(Matrix<R, C, T> lhs, const Matrix<C, K, T> &rhs) { lhs *= rhs; return lhs; }
+
+/**
+ *  @brief Vector right-multiplication.
+ */
+template<uint8_t R, uint8_t C, typename T = float>
+    constexpr inline Vector<R, T> operator*(const Matrix<R, C, T> &A, const Vector<C, T> &v) {
+        Vector<R, T> output{};
+        for(uint8_t i = 0; i < R; i++) {
+            output[i] = static_cast<T>(0);
+            for(uint8_t j = 0; j < C; j++) {
+                output[i] += v[j]*A(i, j);
+            }
+        }
+        return output;
+    }
+
+/**
+ *  @brief Scalar matrix divison.
+ */
+template<uint8_t R, uint8_t C, typename T = float>
+    constexpr inline Matrix<R, C, T> operator/(Matrix<R, C, T> lhs, float c) { lhs /= c; return lhs; }
+
+/**
+ *  @brief Matrix equality.
+ */
+template<uint8_t R, uint8_t C, typename T = float>
+    constexpr inline bool operator==(const Matrix<R, C, T> &lhs, const Matrix<R, C, T> &rhs) { 
+        for(uint8_t i = 0; i < R; i++) {
+            for(uint8_t j = 0; j < C; j++) {
+                if(std::abs(lhs(i, j) - rhs(i, j)) > static_cast<T>(MATRIX_EQUAL_THRESHOLD)) return false;
+            }
+        }
+
+        return true;
+    }
+
+/**
+ *  @brief Matrix inequality.
+ */
+template<uint8_t R, uint8_t C, typename T = float>
+    constexpr inline bool operator!=(const Matrix<R, C, T> &lhs, const Matrix<R, C, T> &rhs) { return (!(lhs == rhs)); }
+
+// ---------------- Non-member Functions ----------------
+/**
+ *  @brief Determinant of a matrix
+ *  @param A Matrix to get determinant of
+ */
+template<uint8_t N, typename T = float>
+    constexpr inline T det(const Matrix<N, N, T> &A) {
+        T output = static_cast<T>(0);
+
+        switch(N) {
+            case 1: { output = static_cast<T>(A(0, 0))  ; break; }
+            case 2: { 
+                output += static_cast<T>(A(0, 0)*A(1, 1));
+                output -= static_cast<T>(A(0, 1)*A(1, 0));
+                break;
+            }
+            case 3: {
+                output += static_cast<T>(A(0, 0)*A(1, 1)*A(2, 2) + A(0, 1)*A(1, 2)*A(2, 0) + A(0, 2)*A(1, 0)*A(2, 1));
+                output -= static_cast<T>(A(0, 2)*A(1, 1)*A(2, 0) + A(0, 0)*A(1, 2)*A(2, 1) + A(0, 1)*A(1, 0)*A(2, 2));
+                break;
+            }
+            default: {
+                Matrix<N, N, T> L, U;
+                Vector<N, T> P;
+
+                if(!decompLU(A, L, U, P)) { output = static_cast<T>(0); break; } // Singualr => det(A) = 0
+
+                uint8_t swapCount = 0;
+                std::array<bool, N> visited{false};
+
+                for(uint8_t i = 0; i < N; i++) {
+                    if(!visited[i]) {
+                        uint8_t cycle = 0;
+                        uint8_t j = i;
+                        while(!visited[j]) {
+                            visited[j] = true;
+                            j = P[j];
+                            cycle++;
+                        }
+
+                        if(cycle > 0) { swapCount += cycle-1; }
+                    }
+                }
+
+                output = (swapCount % 2 == 0) ?static_cast<T>(1) :static_cast<T>(-1);
+                output *= static_cast<T>(traceProduct(U));
+                break;
+            }
+        }
+
+        return output;
+    }
+
+/**
+ *  @brief Matrix transposition
+ *  @param A Matrix to transpose
+ */
+template<uint8_t R, uint8_t C, typename T = float>
+    constexpr inline Matrix<C, R, T> transpose(const Matrix<R, C, T> &A) {
+        Matrix<C, R, T> output{};
+
+        for(uint8_t i = 0; i < C; i++) {
+            for(uint8_t j = 0; j < R; j++) {
+                output(i, j) = A(j, i);
+            }
+        }
+        
+        return output;
+    }
+
+/**
+ *  @brief Compute inverse of a matrix
+ *  @param A Matrix to invert
+ *  @param Ainv Inverted Matrix
+ */
+template<uint8_t N, typename T = float>
+    [[nodiscard]] constexpr inline bool inv(const Matrix<N, N, T> &A, Matrix<N, N, T> &Ainv) {
+        switch(N) {
+            case 1: { Ainv(0, 0) = 1.0f / A(0, 0); return true; }   //TODO check A(0,0) = 0 case
+            case 2: { 
+                float denom = static_cast<float>(det(A));
+                if(std::fabs(denom) < MATRIX_EQUAL_THRESHOLD) { return false; }    // Singular
+                Ainv(0, 0) = A(1, 1) / denom;
+                Ainv(0, 1) = -A(0, 1) / denom;
+                Ainv(1, 0) = -A(1, 0) / denom;
+                Ainv(1, 1) = -A(0, 0) / denom;
+
+                return true;
+            }
+            case 3: { 
+                float denom = static_cast<float>(det(A));
+                if(std::fabs(denom) < MATRIX_EQUAL_THRESHOLD) { return false; }    // Singular
+
+                Ainv(0, 0) =  (A(1,1)*A(2,2) - A(1,2)*A(2,1)) / denom;
+                Ainv(0, 1) = -(A(0,1)*A(2,2) - A(0,2)*A(2,1)) / denom;
+                Ainv(0, 2) =  (A(0,1)*A(1,2) - A(0,2)*A(1,1)) / denom;
+
+                Ainv(1, 0) = -(A(1,0)*A(2,2) - A(1,2)*A(2,0)) / denom;
+                Ainv(1, 1) =  (A(0,0)*A(2,2) - A(0,2)*A(2,0)) / denom;
+                Ainv(1, 2) = -(A(0,0)*A(1,2) - A(0,2)*A(1,0)) / denom;
+
+                Ainv(2, 0) =  (A(1,0)*A(2,1) - A(1,1)*A(2,0)) / denom;
+                Ainv(2, 1) = -(A(0,0)*A(2,1) - A(0,1)*A(2,0)) / denom;
+                Ainv(2, 2) =  (A(0,0)*A(1,1) - A(0,1)*A(1,0)) / denom;
+                return true;
+            }
+            default: { 
+                Matrix<N, N, T> L, U;
+                Vector<N, T> P;
+
+                if(!decompLU(A, L, U, P)) { return false; } // Singular
+
+                for(uint8_t j = 0; j < N; j++) {
+                    Vector<N, T> e{}, x{};
+                    e[j] = static_cast<T>(1);
+
+                    if(!solve(A, e, x)) { return false; }   // Singular
+
+                    for(uint8_t i = 0; i < N; i++) {
+                        Ainv(i, j) = x[i];
+                    }
+                }
+
+                return true;
+            }
+        }
+    }
+
+/**
+ *  @brief Compute matrix trace
+ *  @param A Matrix to compute trace of 
+ */
+template<uint8_t R, uint8_t C, typename T = float>
+    constexpr inline T trace(const Matrix<R, C, T> &A) {
+        T output = static_cast<T>(0);
+
+        for(uint8_t i = 0; i < C; i++) {
+            output += A(i, i);
+        }
+        
+        return output;
+    }
+
+/**
+ *  @brief Compute matrix trace product/geometric trace/diagonal product
+ *  @param A Matrix to compute trace product of 
+ */
+template<uint8_t R, uint8_t C, typename T = float>
+    constexpr inline T traceProduct(const Matrix<R, C, T> &A) {
+        T output = static_cast<T>(1);
+
+        for(uint8_t i = 0; i < C; i++) {
+            output *= A(i, i);
+        }
+        
+        return output;
+    }
+
+/**
+ *  @brief Solve the linear system A * x = b.
+ *  @param A Coefficient matrix.
+ *  @param b Right-hand side vector.
+ *  @param x Output, solution vector.
+ *  @return Whether the solution was successful. If not, A is singular thus no composion is possible.
+ *  @note Return value should not be ignored and handled properly if A is singular.
+ */
+template<uint8_t N, typename T = float>
+    [[nodiscard]] inline bool solve(const Matrix<N, N, T> &A, const Vector<N, T> &b, Vector<N, T> &x) {
+        Matrix<N, N, T> L, U;
+        Vector<N, T> P;
+        
+        if(!decompLU(A, L, U, P)) { return false; }    // Singular
+
+        // Solve for Pb = b'
+        Vector<N, T> bp{};
+        for(uint8_t i = 0; i < N; i++) { bp[i] = b[P[i]]; }
+
+        Vector<N, T> y{}; 
+        for(uint8_t i = 0; i < N; i++) { // Solve for L*y = b', frwd sub
+            T sum = static_cast<T>(bp[i]);
+
+            for(uint8_t j = 0; j < i; j++) {
+                sum -= L(i,j) * y[j];
+            }
+
+            y[i] = sum;
+        }
+
+         
+        for(int i = N-1; i >= 0; i--) { // Solve for U*x = y, bcwd sub
+            T sum = y[i];
+
+            for(uint8_t j = i+1; j < N; j++) {
+                sum -= U(i,j) * x[j];
+            }
+
+            if(static_cast<T>(std::fabs(U(i, i))) < static_cast<T>(MATRIX_EQUAL_THRESHOLD)) { return false; } // Singular
+
+            x[i] = sum / U(i, i);
+        }
+
+        return true;
+    }
+
+} // cobalt::math::linear_algebra

--- a/include/cobalt/math/linear_algebra/matrix/matrix_util.hpp
+++ b/include/cobalt/math/linear_algebra/matrix/matrix_util.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "matrix.hpp"
+
+#include "../vector/vector_util.hpp"
+
+namespace cobalt::math::linear_algebra {
+
+// ---------------- Non-member Utility ----------------
+/**
+ *  @brief Compute the LU-decomposion of a matrix.
+ * 
+ *  Decomposes A into L & U matricies such that P*A = L*U. 
+ * 
+ *  @param A Matrix to LU-decompose.
+ *  @param L Lower triangular matrix (NxN) decomposion output.
+ *  @param U Upper triangular matrix (NxN) decomposion output.
+ *  @param P Permutation vector output.
+ *  @return `true` if decomposision succeeds, `false` if A is signular.
+ *  @note Return value should not be ignored and handled properly if A is singular
+ */
+template<uint8_t N, typename T>
+    [[nodiscard]] bool decompLU(const Matrix<N, N, T> &A, Matrix<N, N, T> &L, Matrix<N, N, T> &U, Vector<N, T> &P) {
+        L = Matrix<N, N, T>::eye();
+        U = A;
+        for(uint8_t i = 0; i < N; i++) P[i] = i;
+        
+        for(uint8_t k = 0; k < N; k++) {
+            // Get pivot
+            T maxVal = static_cast<T>(std::fabs(U(k, k)));
+            uint8_t pivot = k;
+
+            for(uint8_t i = k+1; i < N; i++) {
+                T val = static_cast<T>(std::fabs(U(i, k)));
+                if(val > maxVal) {
+                    maxVal = val;
+                    pivot = i;
+                }
+            }
+
+            if(maxVal < static_cast<T>(MATRIX_EQUAL_THRESHOLD)) { return false; } // Singular matrix
+
+            // Swap rows
+            if(pivot != k) {
+                for(uint8_t j = 0; j < N; j++) {
+                    std::swap(U(k, j), U(pivot, j));
+                }
+
+                for(uint8_t j = 0; j < k; j++) {
+                    std::swap(L(k, j), L(pivot, j));
+                }
+                
+                std::swap(P[k], P[pivot]);
+            }
+
+            // Elimination
+            for(uint8_t i = k+1; i<N; i++) {
+                T factor = U(i, k) / U(k, k);
+                L(i, k) = factor;
+
+                for(uint8_t j = k; j < N; j++) {
+                    U(i, j) -= factor * U(k, j);
+                }
+            }
+        }
+
+        return true;    // Non-Singular
+    }
+
+} // cobalt::math::linear_algebra

--- a/include/cobalt/math/linear_algebra/vector/vector.hpp
+++ b/include/cobalt/math/linear_algebra/vector/vector.hpp
@@ -8,6 +8,7 @@
 namespace cobalt::math::linear_algebra {
 
 constexpr uint8_t VECTOR_MAX_SIZE = 12;
+
 constexpr float   VECTOR_EQUAL_THRESHOLD = 1e-5;
 constexpr float   VECTOR_ZERO_THRESHOLD = 1e-12;
 

--- a/include/cobalt/math/linear_algebra/vector/vector_util.hpp
+++ b/include/cobalt/math/linear_algebra/vector/vector_util.hpp
@@ -6,6 +6,8 @@
 
 #include "vector.hpp"
 
+#include "../matrix/matrix.hpp"
+
 namespace cobalt::math::linear_algebra {
 
 // ---------------- Member Utility ----------------
@@ -232,9 +234,28 @@ constexpr inline Vector<N, T> fromArray(const std::array<T, N> &arr) {
     return v;
 }
 
+/**
+ *  @brief Construct a skew-symmetric matrix(3x3)from a vector(3).
+ *  @param v Vector to turn into a skew-symmetric matrix.
+ */
+template<typename T = float>
+constexpr inline Matrix<3, 3, T> skew(const Vector<3, T> &v) {
+    Matrix<3, 3, T> output = Matrix<3, 3, T>::zero();
+
+    output(0, 1) = -v.z();
+    output(0, 2) =  v.y();
+    output(1, 2) = -v.x();
+
+    output(1, 0) =  v.z();
+    output(2, 0) = -v.y();
+    output(2, 1) =  v.x();
+
+    return output;
+}
+
 // ---------------- Checks ----------------
 /**
- *  @brief Convert a vector to std::array.
+ *  @brief Check if a vector is normalized (norm = 1)
  */
 template<uint8_t N, typename T = float>
 constexpr inline bool isNormalized(const Vector<N, T> &v) {

--- a/include/cobalt/math/linear_algebra/vector/vector_util.hpp
+++ b/include/cobalt/math/linear_algebra/vector/vector_util.hpp
@@ -225,7 +225,7 @@ constexpr inline std::array<T, N> toArray(const Vector<N, T> &v) {
  *  @brief Construct a vector from std::array.
  */
 template<uint8_t N, typename T = float>
-constexpr inline Vector<N, T> fromArray(const std::array<T, N> &arr) {
+constexpr inline Vector<N, T> fromArray(const std::array<T, N> &arr) {  // TODO: Fix usage
     Vector<N, T> v;
     for(uint8_t i = 0; i < N; i++) {
         v[i] = arr[i];

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,8 @@
 add_executable(cobalt_tests
     sanity_test.cpp
 
-    ./math/linear_algebra/vector_test.cpp
+    #./math/linear_algebra/vector_test.cpp
+    ./math/linear_algebra/matrix_test.cpp
 )
 
 # Include paths

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@
 add_executable(cobalt_tests
     sanity_test.cpp
 
-    #./math/linear_algebra/vector_test.cpp
+    ./math/linear_algebra/vector_test.cpp
     ./math/linear_algebra/matrix_test.cpp
 )
 

--- a/tests/math/linear_algebra/matrix_test.cpp
+++ b/tests/math/linear_algebra/matrix_test.cpp
@@ -63,6 +63,42 @@ TEST_CASE("Matrix, zero & identity construction", "[matrix]") {
     REQUIRE(B(2, 1) == Catch::Approx(0.0f));
 }  
 
+TEST_CASE("Matrix, block & toVector", "[matrix]") {
+    Matrix<3, 3> A{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}, {7.0f, 8.0f, 9.0f}};
+    Matrix<2, 2> B = A.block<2, 2>();
+    Matrix<2, 2> C = A.block<2, 2>(1, 1);
+    Matrix<3, 3> D = A.block<3,3>();
+    Matrix<3, 1> F = A.block<3,1>(0, 1);
+
+    Vector<3> v = toVector(A);
+    Vector<3> u = toVector(A, 1);
+
+    REQUIRE(v[0] == Catch::Approx(1.0f));
+    REQUIRE(v[1] == Catch::Approx(4.0f));
+    REQUIRE(v[2] == Catch::Approx(7.0f));
+
+    REQUIRE(B(0, 0) == Catch::Approx(1.0f));
+    REQUIRE(B(0, 1) == Catch::Approx(2.0f));
+    REQUIRE(B(1, 0) == Catch::Approx(4.0f));
+    REQUIRE(B(1, 1) == Catch::Approx(5.0f));
+
+    REQUIRE(C(0, 0) == Catch::Approx(5.0f));
+    REQUIRE(C(0, 1) == Catch::Approx(6.0f));
+    REQUIRE(C(1, 0) == Catch::Approx(8.0f));
+    REQUIRE(C(1, 1) == Catch::Approx(9.0f));
+
+    for(uint8_t i = 0; i < 3; i++) {
+        REQUIRE(u[i] == Catch::Approx(F(i, 0)).margin(1e-6));
+    }
+
+    for(uint8_t i = 0; i < 3; i++) {
+        for(uint8_t j = 0; j < 3; j++) {
+            REQUIRE(D(i,j) == Catch::Approx(A(i,j)).margin(1e-6));
+        }
+    }
+    
+}   
+
 TEST_CASE("Matrix, arithmetic operations", "[matrix]") {
     Matrix<3, 3> A{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}, {7.0f, 8.0f, 9.0f}};
     Matrix<3, 3> B{{1.0f, 1.0f, 1.0f}, {1.0f, 1.0f, 1.0f}, {1.0f, 1.0f, 1.0f}};
@@ -213,6 +249,17 @@ TEST_CASE("Matrix, inverse", "[matrix]") {
 
 }  
 
+TEST_CASE("Matrix, rank", "[matrix]") {
+    Matrix<3, 3> A{{1.0f, 2.0f, 0.7f}, {4.0f, 0.5f, 6.0f}, {2.0f, -0.3f, 12.0f}};
+    Matrix<3, 3> B{{1.0f, 2.0f, 3.0f}, {4.0f, 0.5f, 12.0f}, {2.0f, -0.3f, 6.0f}};
+    Matrix<3, 3> C{{1.0f, 2.0f, 3.0f}, {4.0f, 8.0f, 12.0f}, {2.0f, 4.0f, 6.0f}};
+
+    REQUIRE(rank(A) == 3);
+    REQUIRE(rank(B) == 2);
+    REQUIRE(rank(C) == 1);
+}   
+
+
 TEST_CASE("Matrix, trace & traceProduct", "[matrix]") {
     Matrix<3, 3> A{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}, {7.0f, 8.0f, 9.0f}};
 
@@ -231,6 +278,39 @@ TEST_CASE("Matrix, solve", "[matrix]") {
     REQUIRE(x.y() == Catch::Approx(-9.19048));
     REQUIRE(x.z() == Catch::Approx(5.48413));
 }   
+
+TEST_CASE("Matrix, jacobi", "[matrix]") {
+    Matrix<3, 3> A{{4.0f, 1.5f, 0.0f}, {1.5f, 3.0f, 1.5f}, {0.0f, 1.5f, 5.0f}};
+    Matrix<3,3> V;
+    Vector<3> e;
+
+    CAPTURE(jacobi(A, e, V));
+
+    CAPTURE(A.toString());
+
+    REQUIRE(e[0] == Catch::Approx(6.10502).margin(1e-6));
+    REQUIRE(e[1] == Catch::Approx(4.42284).margin(1e-6));
+    REQUIRE(e[2] == Catch::Approx(1.47214).margin(1e-6));
+}
+
+TEST_CASE("Matrix, SVD", "[matrix]") {
+        Matrix<3, 3> A{{4.0f, 1.0f, 0.0f}, {2.0f, 3.0f, 1.0f}, {0.0f, 2.0f, 5.0f}};
+    Matrix<3, 3> U, S, V;
+
+    svd(A, U, S, V);
+
+    Matrix<3, 3> USVt = U*S*transpose(V);
+
+    for(uint8_t i = 0; i < 3; i++) {
+        for(uint8_t j = 0; j < 3; j++) {
+            REQUIRE(USVt(i, j) == Catch::Approx(A(i,j)).margin(1e-6));
+        }
+    }
+
+    REQUIRE(S(0,0) == Catch::Approx(6.12267).margin(1e-6));
+    REQUIRE(S(1,1) == Catch::Approx(4.49235).margin(1e-6));
+    REQUIRE(S(2,2) == Catch::Approx(1.52698).margin(1e-6));
+}
 
 TEST_CASE("Matrix, LU-decomposion", "[matrix]") {
     Matrix<3, 3> A{{4.0f, 3.0f, 2.0f}, {2.0f, 1.0f, 3.0f}, {67.0f, 7.0f, 8.0f}};
@@ -267,6 +347,75 @@ TEST_CASE("Matrix, LU-decomposion", "[matrix]") {
             REQUIRE(PA(i,j) == Catch::Approx(LU(i,j)).margin(1e-6));
         }
     }
+}   
+
+TEST_CASE("Matrix, QR Decomposion", "[matrix]") {
+    Matrix<3, 3> A{ {12.0f, -51.0f, 4.0f,},
+                    {6.0f, 167.0f, -68.0f,},
+                    {-4.0f, 24.0f, -41.0f,}};
+    Matrix<3,3> Q, R;
+
+    REQUIRE(decompQR(A, Q, R));
+
+    Matrix<3, 3> QtQ = transpose(Q) * Q;
+    Matrix<3, 3> I = Matrix<3,3>::eye();
+
+    for(uint8_t i = 0; i < 3; i++) {
+        for(uint8_t j = 0; j < 3; j++) {
+            REQUIRE(QtQ(i, j) == Catch::Approx(I(i, j)).margin(1e-6));
+        }
+    }
+
+    Matrix<3, 3> QR = Q * R;
+
+    for(uint8_t i = 0; i < 3; i++) {
+        for(uint8_t j = i+1; j < 3; j++) {
+            REQUIRE(QR(i, j) == Catch::Approx(A(i, j)).margin(1e-6));
+        }
+    }
+}   
+
+TEST_CASE("Matrix, Gram Schmidt", "[matrix]") {
+    Matrix<3, 3> A{ {1.0f, 1.0f, 0.0f,},
+                    {1.0f, 0.0f, 1.0f,},
+                    {0.0f, 1.0f, 1.0f,}};
+
+    Matrix<3, 3> B{ {1.0f, 1.0f, 3.0f,},
+                    {1.0f, 0.0f, 3.0f,},
+                    {1.0f, 1.0f, 3.0f,}};
+
+    Matrix<3,3> Q;
+
+    REQUIRE(gramSchmidt(A, Q));
+
+    for(uint8_t j = 0; j < 3; j++) {
+        Vector<3> colVec = toVector(Q, j);
+        REQUIRE(norm(colVec) == Catch::Approx(1.0f).margin(1e-6));
+    }
+
+    for(uint8_t i = 0; i < 3; i++) {
+        for(uint8_t j = i+1; j < 3; j++) {
+            float dotAB = dot(toVector(Q, i), toVector(Q, j)); 
+            REQUIRE(dotAB == Catch::Approx(0.0f).margin(1e-6));
+        }
+    }
+
+    REQUIRE(!gramSchmidt(B, Q));
+}   
 
 
+TEST_CASE("Matrix, diagonal matrix", "[matrix]") {
+    Vector<6> v{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+    Matrix<6,6> A = Matrix<6,6>::diagonal(v);
+    Matrix<8,8> B = Matrix<8,8>::diagonal(v);
+
+    for(uint8_t i = 0; i < 6; i++) {
+         REQUIRE(A(i,i) == Catch::Approx(v[i]).margin(1e-6));
+    }
+
+    for(uint8_t i = 0; i < 8; i++) {
+        if(i < 6) { REQUIRE(B(i,i) == Catch::Approx(v[i]).margin(1e-6)); }
+        else { REQUIRE(B(i,i) == Catch::Approx(0.0f).margin(1e-6)); }
+    }
+    
 }   

--- a/tests/math/linear_algebra/matrix_test.cpp
+++ b/tests/math/linear_algebra/matrix_test.cpp
@@ -1,0 +1,272 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <cobalt/math/linear_algebra/matrix/matrix.hpp>
+#include <cobalt/math/linear_algebra/matrix/matrix_ops.hpp>
+#include <cobalt/math/linear_algebra/matrix/matrix_util.hpp>
+
+#include <cobalt/math/linear_algebra/vector/vector.hpp>
+
+using cobalt::math::linear_algebra::Matrix;
+using cobalt::math::linear_algebra::Vector;
+
+TEST_CASE("Matrix, default construction", "[matrix]") {
+    Matrix<2, 2> A;
+
+    REQUIRE(A(0, 0) == Catch::Approx(0.0f));
+    REQUIRE(A(0, 1) == Catch::Approx(0.0f));
+    REQUIRE(A(1, 0) == Catch::Approx(0.0f));
+    REQUIRE(A(1, 1) == Catch::Approx(0.0f));
+}   
+
+TEST_CASE("Matrix, manual construction", "[matrix]") {
+    Matrix<2, 2> A = {{0.0f, 1.0f}, {2.0f, 3.0f}};
+
+    REQUIRE(A(0, 0) == Catch::Approx(0.0f));
+    REQUIRE(A(0, 1) == Catch::Approx(1.0f));
+    REQUIRE(A(1, 0) == Catch::Approx(2.0f));
+    REQUIRE(A(1, 1) == Catch::Approx(3.0f));
+}   
+
+TEST_CASE("Matrix, zero & identity construction", "[matrix]") {
+    Matrix<3, 3> A = Matrix<3, 3>::zero();
+
+    REQUIRE(A(0, 0) == Catch::Approx(0.0f));
+    REQUIRE(A(0, 1) == Catch::Approx(0.0f));
+    REQUIRE(A(0, 2) == Catch::Approx(0.0f));
+    REQUIRE(A(1, 0) == Catch::Approx(0.0f));
+    REQUIRE(A(1, 1) == Catch::Approx(0.0f));
+    REQUIRE(A(1, 2) == Catch::Approx(0.0f));
+    REQUIRE(A(2, 0) == Catch::Approx(0.0f));
+    REQUIRE(A(2, 1) == Catch::Approx(0.0f));
+    REQUIRE(A(2, 2) == Catch::Approx(0.0f));
+
+    A = Matrix<3, 3>::eye();
+
+    REQUIRE(A(0, 0) == Catch::Approx(1.0f));
+    REQUIRE(A(0, 1) == Catch::Approx(0.0f));
+    REQUIRE(A(0, 2) == Catch::Approx(0.0f));
+    REQUIRE(A(1, 0) == Catch::Approx(0.0f));
+    REQUIRE(A(1, 1) == Catch::Approx(1.0f));
+    REQUIRE(A(1, 2) == Catch::Approx(0.0f));
+    REQUIRE(A(2, 0) == Catch::Approx(0.0f));
+    REQUIRE(A(2, 1) == Catch::Approx(0.0f));
+    REQUIRE(A(2, 2) == Catch::Approx(1.0f));
+
+    Matrix<3, 2> B = Matrix<3, 2>::eye();
+
+    REQUIRE(B(0, 0) == Catch::Approx(1.0f));
+    REQUIRE(B(0, 1) == Catch::Approx(0.0f));
+    REQUIRE(B(1, 0) == Catch::Approx(0.0f));
+    REQUIRE(B(1, 1) == Catch::Approx(1.0f));
+    REQUIRE(B(2, 0) == Catch::Approx(0.0f));
+    REQUIRE(B(2, 1) == Catch::Approx(0.0f));
+}  
+
+TEST_CASE("Matrix, arithmetic operations", "[matrix]") {
+    Matrix<3, 3> A{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}, {7.0f, 8.0f, 9.0f}};
+    Matrix<3, 3> B{{1.0f, 1.0f, 1.0f}, {1.0f, 1.0f, 1.0f}, {1.0f, 1.0f, 1.0f}};
+
+    A += B;
+
+    REQUIRE(A(0, 0) == Catch::Approx(2.0f));
+    REQUIRE(A(0, 1) == Catch::Approx(3.0f));
+    REQUIRE(A(0, 2) == Catch::Approx(4.0f));
+    REQUIRE(A(1, 0) == Catch::Approx(5.0f));
+    REQUIRE(A(1, 1) == Catch::Approx(6.0f));
+    REQUIRE(A(1, 2) == Catch::Approx(7.0f));
+    REQUIRE(A(2, 0) == Catch::Approx(8.0f));
+    REQUIRE(A(2, 1) == Catch::Approx(9.0f));
+    REQUIRE(A(2, 2) == Catch::Approx(10.0f));
+
+    A -= B;
+
+    REQUIRE(A(0, 0) == Catch::Approx(1.0f));
+    REQUIRE(A(0, 1) == Catch::Approx(2.0f));
+    REQUIRE(A(0, 2) == Catch::Approx(3.0f));
+    REQUIRE(A(1, 0) == Catch::Approx(4.0f));
+    REQUIRE(A(1, 1) == Catch::Approx(5.0f));
+    REQUIRE(A(1, 2) == Catch::Approx(6.0f));
+    REQUIRE(A(2, 0) == Catch::Approx(7.0f));
+    REQUIRE(A(2, 1) == Catch::Approx(8.0f));
+    REQUIRE(A(2, 2) == Catch::Approx(9.0f));
+
+    A *= B;
+
+    REQUIRE(A(0, 0) == Catch::Approx(6.0f));
+    REQUIRE(A(0, 1) == Catch::Approx(6.0f));
+    REQUIRE(A(0, 2) == Catch::Approx(6.0f));
+    REQUIRE(A(1, 0) == Catch::Approx(15.0f));
+    REQUIRE(A(1, 1) == Catch::Approx(15.0f));
+    REQUIRE(A(1, 2) == Catch::Approx(15.0f));
+    REQUIRE(A(2, 0) == Catch::Approx(24.0f));
+    REQUIRE(A(2, 1) == Catch::Approx(24.0f));
+    REQUIRE(A(2, 2) == Catch::Approx(24.0f));
+
+    A *= 0.5;
+
+    REQUIRE(A(0, 0) == Catch::Approx(3.0f));
+    REQUIRE(A(0, 1) == Catch::Approx(3.0f));
+    REQUIRE(A(0, 2) == Catch::Approx(3.0f));
+    REQUIRE(A(1, 0) == Catch::Approx(7.5f));
+    REQUIRE(A(1, 1) == Catch::Approx(7.5f));
+    REQUIRE(A(1, 2) == Catch::Approx(7.5f));
+    REQUIRE(A(2, 0) == Catch::Approx(12.0f));
+    REQUIRE(A(2, 1) == Catch::Approx(12.0f));
+    REQUIRE(A(2, 2) == Catch::Approx(12.0f));
+
+    A = -A;
+
+    REQUIRE(A(0, 0) == Catch::Approx(-3.0f));
+    REQUIRE(A(0, 1) == Catch::Approx(-3.0f));
+    REQUIRE(A(0, 2) == Catch::Approx(-3.0f));
+    REQUIRE(A(1, 0) == Catch::Approx(-7.5f));
+    REQUIRE(A(1, 1) == Catch::Approx(-7.5f));
+    REQUIRE(A(1, 2) == Catch::Approx(-7.5f));
+    REQUIRE(A(2, 0) == Catch::Approx(-12.0f));
+    REQUIRE(A(2, 1) == Catch::Approx(-12.0f));
+    REQUIRE(A(2, 2) == Catch::Approx(-12.0f));
+}   
+
+TEST_CASE("Matrix, vector multiplication", "[matrix]") {
+    Matrix<3, 3> A{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}, {7.0f, 8.0f, 9.0f}};
+    Matrix<3, 3> R{{0.0f, -1.0f, 0.0f}, {1.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 1.0f}};
+    Matrix<2, 3> I = Matrix<2, 3>::eye();
+
+    Vector<3> v{1.0f, 1.0f, 1.0f};
+    Vector<3> u{3.0f, 4.0f, 0.0f};
+
+    Vector<3> w = A*v;
+    Vector<3> r = R*u;
+    Vector<2> a = I*u;
+
+    REQUIRE(w[0] == Catch::Approx(6.0f));
+    REQUIRE(w[1] == Catch::Approx(15.0f));
+    REQUIRE(w[2] == Catch::Approx(24.0f));
+
+    REQUIRE(r[0] == Catch::Approx(-4.0f));
+    REQUIRE(r[1] == Catch::Approx(3.0f));
+    REQUIRE(r[2] == Catch::Approx(0.0f));
+
+    REQUIRE(a[0] == Catch::Approx(3.0f));
+    REQUIRE(a[1] == Catch::Approx(4.0f));
+}   
+
+TEST_CASE("Matrix, determinant", "[matrix]") {
+    Matrix<1, 1> A{{5}};
+    Matrix<2, 2> B{{1.0f, 2.0f}, {3.0f, 4.0f}};
+    Matrix<3, 3> C{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}, {7.0f, 8.0f, 9.0f}};
+    Matrix<4, 4> D{{1.0f, 2.0f, 3.0f, 4.0f}, {5.0f, 6.0f, 3.0f, 8.0f}, {9.0f, 9.0f, 11.0f, 12.0f}, {13.0f, 14.0f, 15.0f, 16.0f}};
+
+    REQUIRE(det(A) == Catch::Approx(5.0f));
+    REQUIRE(det(B) == Catch::Approx(-2.0f));
+    REQUIRE(det(C) == Catch::Approx(0.0f));
+    REQUIRE(det(D) == Catch::Approx(144.0f));
+}   
+
+TEST_CASE("Matrix, transposition", "[matrix]") {
+    Matrix<3, 3> A{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}, {7.0f, 8.0f, 9.0f}};
+    Matrix<2, 3> B = {{2.0f, 10.0f, -1.0f}, {3.0f, -3.5f, 0.5f}};
+
+    A = transpose(A);
+    Matrix<3, 2>Bt = transpose(B);
+
+    REQUIRE(A(0, 0) == Catch::Approx(1.0f));
+    REQUIRE(A(0, 1) == Catch::Approx(4.0f));
+    REQUIRE(A(0, 2) == Catch::Approx(7.0f));
+    REQUIRE(A(1, 0) == Catch::Approx(2.0f));
+    REQUIRE(A(1, 1) == Catch::Approx(5.0f));
+    REQUIRE(A(1, 2) == Catch::Approx(8.0f));
+    REQUIRE(A(2, 0) == Catch::Approx(3.0f));
+    REQUIRE(A(2, 1) == Catch::Approx(6.0f));
+    REQUIRE(A(2, 2) == Catch::Approx(9.0f));
+
+    REQUIRE(Bt(0, 0) == Catch::Approx(2.0f));
+    REQUIRE(Bt(0, 1) == Catch::Approx(3.0f));
+    REQUIRE(Bt(1, 0) == Catch::Approx(10.0f));
+    REQUIRE(Bt(1, 1) == Catch::Approx(-3.5f));
+    REQUIRE(Bt(2, 0) == Catch::Approx(-1.0f));
+    REQUIRE(Bt(2, 1) == Catch::Approx(0.5f));
+}   
+
+TEST_CASE("Matrix, inverse", "[matrix]") {
+    Matrix<3, 3> A{{1.0f, 2.0f, 6.0f}, {-2.0f, 5.0f, 6.0f}, {7.0f, 1.0f, 9.0f}};
+    Matrix<3, 3> Ainv;
+
+    REQUIRE(inv(A, Ainv));
+
+    Matrix<3, 3> I = Matrix<3, 3>::eye();
+    Matrix<3, 3> AAi = A * Ainv;
+    Matrix<3, 3> AiA = Ainv * A;
+
+    for(uint8_t i = 0; i < 3; i++) {
+        for(uint8_t j = 0; j < 3; j++) {
+            REQUIRE(AAi(i,j) == Catch::Approx(I(i,j)).margin(1e-6));
+        }
+    }
+
+    for(uint8_t i = 0; i < 3; i++) {
+        for(uint8_t j = 0; j < 3; j++) {
+            REQUIRE(AiA(i,j) == Catch::Approx(I(i,j)).margin(1e-6));
+        }
+    }
+
+}  
+
+TEST_CASE("Matrix, trace & traceProduct", "[matrix]") {
+    Matrix<3, 3> A{{1.0f, 2.0f, 3.0f}, {4.0f, 5.0f, 6.0f}, {7.0f, 8.0f, 9.0f}};
+
+    REQUIRE(trace(A) == Catch::Approx(15.0f));
+    REQUIRE(traceProduct(A) == Catch::Approx(45.0f));
+}   
+
+TEST_CASE("Matrix, solve", "[matrix]") {
+    Matrix<3, 3> A{{1.0f, 2.0f, 6.0f}, {-2.0f, 5.0f, 6.0f}, {7.0f, 1.0f, 9.0f}};
+    Vector<3> b{9.0f, -2.0f, 1.5f};
+    Vector<3> x = Vector<3>::zero();
+
+    REQUIRE(solve(A, b, x));
+
+    REQUIRE(x.x() == Catch::Approx(-5.52381));
+    REQUIRE(x.y() == Catch::Approx(-9.19048));
+    REQUIRE(x.z() == Catch::Approx(5.48413));
+}   
+
+TEST_CASE("Matrix, LU-decomposion", "[matrix]") {
+    Matrix<3, 3> A{{4.0f, 3.0f, 2.0f}, {2.0f, 1.0f, 3.0f}, {67.0f, 7.0f, 8.0f}};
+    Matrix<3, 3> L, U;
+    Vector<3> P;
+
+    REQUIRE(decompLU(A, L, U, P));
+
+    for(uint8_t i = 0; i < 3; i++) {
+        REQUIRE(L(i,i) == Catch::Approx(1.0f));
+        for(uint8_t j = i+1; j < 3; j++) {
+            REQUIRE(L(i,j) == Catch::Approx(0.0f));
+        }
+    }
+
+    for(uint8_t i = 1; i < 3; i++) {
+        for(uint8_t j = 0; j < i; j++) {
+            REQUIRE(U(i,j) == Catch::Approx(0.0f));
+        }
+    }
+
+    Matrix<3,3> PA;
+
+    for(uint8_t i = 0; i < 3; i++) {
+        for(uint8_t j = 0; j < 3; j++) {
+            PA(i, j) = A(P[i], j);
+        }
+    }
+
+    Matrix<3,3> LU = L * U;
+
+    for(uint8_t i = 0; i < 3; i++) {
+        for(uint8_t j = 0; j < 3; j++) {
+            REQUIRE(PA(i,j) == Catch::Approx(LU(i,j)).margin(1e-6));
+        }
+    }
+
+
+}   

--- a/tests/math/linear_algebra/vector_test.cpp
+++ b/tests/math/linear_algebra/vector_test.cpp
@@ -6,6 +6,7 @@
 #include <cobalt/math/linear_algebra/vector/vector_util.hpp>
 
 using cobalt::math::linear_algebra::Vector;
+using cobalt::math::linear_algebra::Matrix;
 
 TEST_CASE("Vector, default construction", "[vector]") {
     Vector<3> v;
@@ -47,6 +48,24 @@ TEST_CASE("Vector, from/to array", "[vector]") {
     REQUIRE(arr2[1] == Catch::Approx(2.0f));
     REQUIRE(arr2[2] == Catch::Approx(10.0f));
     REQUIRE(arr2[3] == Catch::Approx(-2.0f));
+}   
+
+TEST_CASE("Vector, skew-symmetric", "[vector]") {
+    Vector<3> v = {3.0f, -1.0f, 0.3f};
+
+    Matrix<3, 3> S = skew(v);
+
+    REQUIRE(S(0, 1) == Catch::Approx(-0.3f));
+    REQUIRE(S(0, 2) == Catch::Approx(-1.0f));
+    REQUIRE(S(1, 2) == Catch::Approx(-3.0f));
+
+    REQUIRE(S(1, 0) == Catch::Approx(0.3f));
+    REQUIRE(S(2, 0) == Catch::Approx(1.0f));
+    REQUIRE(S(2, 1) == Catch::Approx(3.0f));
+
+    REQUIRE(S(0, 0) == Catch::Approx(0.0f));
+    REQUIRE(S(1, 1) == Catch::Approx(0.0f));
+    REQUIRE(S(2, 2) == Catch::Approx(0.0f));
 }   
 
 TEST_CASE("Vector, x,y,z accessors", "[vector]") {

--- a/tests/math/linear_algebra/vector_test.cpp
+++ b/tests/math/linear_algebra/vector_test.cpp
@@ -35,7 +35,7 @@ TEST_CASE("Vector, brace construction", "[vector]") {
 TEST_CASE("Vector, from/to array", "[vector]") {
     std::array<float, 4> arr = {1.0f, 2.0f, 10.0f, -2.0f};
 
-    Vector<4> v = cobalt::math::linear_algebra::fromArray<4>(arr);  //! why?
+    Vector<4> v = cobalt::math::linear_algebra::fromArray<4>(arr);
 
     REQUIRE(v[0] == Catch::Approx(1.0f));
     REQUIRE(v[1] == Catch::Approx(2.0f));


### PR DESCRIPTION
### Overview
The PR introduces the initial `Matrix` implementation into `cobalt::math::linear_algebra`. It provides a fixed-size, templated `Matrix<N, M T>` type with common linear algebra operations, utility functions & tests.

### Key Features
* Core Matrix
  - Fixed-size, templated vector type, `Vector<N, M, T>`
  - Member operator overloads, `[], +=, -=, *=, /=`
  - Static factories, `zero(), eye(), diagonal()`
* MatrixOperations (non-member)
  - Non-member operator overloads, `+, -, *, /, ==, !=`
  - Sub-matrix creator, `block<R, C>()`
  - Determinant, transpose & inverse, `det(), transpose(), inv()`
  - Rank, trace sum & product, `rank(), trace(), traceProd()`
  - System solver for equations of type Ax = b, `solve()`
* Matrix Utilities
  - String representation, `toString()`
  - Jacobi eigenvalue/vector algorithm for symmetric matricies, `jacobi()`
  - Singular-Value decomposion, `svd()`
  - LU & QR decomposion, `decompLU(), decompQR()`
  - Gram-Schmidt ortho-normalization procedure, `gramSchmidt()`
  - Vector conversion, `toVector()`
  - Singular matrix checker, `isSingular()`

### Tests
All tests pass without issue.
  
### Notes
* Functionality for general `eigen()`, `eigenVec()`, `toDual()` will be added later alongside updates to existing functionality for more efficient time and resource usage using helper functions.