### PR TITLE
feat(math): add Complex type

### DIFF
--- a/include/cobalt/math/algebra/algebra.hpp
+++ b/include/cobalt/math/algebra/algebra.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+// ----- Complex Numbers -----
+#include "complex/complex.hpp"          // Core Complex number definition
+#include "complex/complex_ops.hpp"      // -- Complex number arithmetic & math operation defintions
+#include "complex/complex_util.hpp"     // -- Complex number utility tool & algorithm defintions

--- a/include/cobalt/math/algebra/complex/complex.hpp
+++ b/include/cobalt/math/algebra/complex/complex.hpp
@@ -127,7 +127,7 @@ struct Complex {
          */
         constexpr Complex &operator*=(const Complex &rhs) {
             re_ = re_*rhs.re_ - im_*rhs.im_;
-            im_ = re_*rhs.im_ - im_*rhs.re_;
+            im_ = re_*rhs.im_ + im_*rhs.re_;
 
             return *this;
         }
@@ -170,6 +170,16 @@ struct Complex {
         constexpr Complex &operator-() {
             re_ *= -1.0f;
             im_ *= -1.0f;
+
+            return *this;
+        }
+
+        /**
+         *  @brief Set the complex number to the given complex number
+         */
+        constexpr Complex &operator=(const Complex &rhs) {
+            re_ = rhs.re_;
+            im_ = rhs.im_;
 
             return *this;
         }

--- a/include/cobalt/math/algebra/complex/complex.hpp
+++ b/include/cobalt/math/algebra/complex/complex.hpp
@@ -164,6 +164,16 @@ struct Complex {
             return *this;
         }
 
+        /**
+         *  @brief Negate this complex number
+         */
+        constexpr Complex &operator-() {
+            re_ *= -1.0f;
+            im_ *= -1.0f;
+
+            return *this;
+        }
+
 
         // ---------------- Utility  ----------------
         std::string toString(uint8_t percision = COMPLEX_DEFAULT_PRECISION) const;

--- a/include/cobalt/math/algebra/complex/complex.hpp
+++ b/include/cobalt/math/algebra/complex/complex.hpp
@@ -1,0 +1,172 @@
+#pragma once
+
+#include <stdint.h>
+#include <cmath>
+#include <string>
+
+namespace cobalt::math::algebra {
+
+constexpr float COMPLEX_EQUAL_THRESHOLD = 1e-5;
+constexpr float COMPLEX_ZERO_THRESHOLD = 1e-12;
+
+constexpr float COMPLEX_DEFAULT_PRECISION = 3;
+
+// --------------------------------------
+//          Complex Number    
+// --------------------------------------
+
+struct Complex {
+    private:
+        float re_;
+        float im_;
+
+    public:
+        // ---------------- Constructors ----------------
+        /**
+         *  @brief Default, zero-constructor. (0 + 0j)
+         */
+        Complex() noexcept: re_(0.0f), im_(0.0f) {}
+
+        /**
+         *  @brief Construct from real and imaginary parts
+         *  @param real Real part
+         *  @param imag Imaginary part
+         */
+        Complex(float real, float imag = 0.0f) noexcept : re_(real), im_(imag) {}
+
+
+        // ---------------- Static Factories ----------------
+        /**
+         *  @brief Construct 0 + 0j.
+         */
+        static Complex zero() noexcept { return Complex(); }
+
+        /**
+         *  @brief Construct 1 + 0j.
+         */
+        static Complex one() noexcept { return Complex(1.0f); }
+
+        /**
+         *  @brief Construct 0 + 1j.
+         */
+        static Complex oneIm() noexcept { return Complex(0.0f, 1.0f); }
+
+        /**
+         *  @brief Construct reᶦθ
+         *  @param r The norm/magnitude of the complex number
+         *  @param theta The argument/angle of the complex number
+         */
+        static Complex polar(float r, float theta) noexcept { return Complex(r*static_cast<float>(std::cos(theta)), r*static_cast<float>(std::sin(theta))); }
+
+
+        // ---------------- Accessors ----------------
+        /**
+         *  @brief Const access to the real part.
+         *  @return Const reference to real part.
+         */
+        constexpr float real() const { return re_; }
+
+        /**
+         *  @brief Const access to the imaginary part.
+         *  @return Const reference to imaginary part.
+         */
+        constexpr float imag() const { return im_; }
+
+        /**
+         *  @brief Sets the real element
+         */
+        void real(float re) { re_ = re; }
+
+        /**
+         *  @brief Sets the imaginary element
+         */
+        void imag(float im) { im_ = im; }
+
+
+        // ---------------- Operator Overloads ----------------
+        /**
+         *  @brief Add another complex number to this complex number.
+         */
+        constexpr Complex &operator+=(const Complex &rhs) {
+            re_ += rhs.re_;
+            im_ += rhs.im_;
+
+            return *this;
+        }
+
+        /**
+         *  @brief Add a real number to this complex number.
+         */
+        constexpr Complex &operator+=(float c) {
+            re_ += c;
+
+            return *this;
+        }
+
+        /**
+         *  @brief Subtract another complex number from this complex number.
+         */
+        constexpr Complex &operator-=(const Complex &rhs) {
+            re_ -= rhs.re_;
+            im_ -= rhs.im_;
+
+            return *this;
+        }
+
+        /**
+         *  @brief Subtract a real number from this complex number.
+         */
+        constexpr Complex &operator-=(float c) {
+            re_ -= c;
+
+            return *this;
+        }
+
+        /**
+         *  @brief Multiply this complex number by another complex number.
+         */
+        constexpr Complex &operator*=(const Complex &rhs) {
+            re_ = re_*rhs.re_ - im_*rhs.im_;
+            im_ = re_*rhs.im_ - im_*rhs.re_;
+
+            return *this;
+        }
+
+        /**
+         *  @brief Multiply this complex number by a scalar
+         */
+        constexpr Complex &operator*=(float c) {
+            re_ *= c;
+            im_ *= c;
+
+            return *this;
+        }
+
+        /**
+         *  @brief Divide this complex number by another complex number.
+         */
+        constexpr Complex &operator/=(const Complex &rhs) {
+            float denom = rhs.re_*rhs.re_ + rhs.im_*rhs.im_;
+            
+            re_ = (re_*rhs.re_ - im_*rhs.im_) / denom;
+            im_ = (re_*rhs.im_ - im_*rhs.re_) / denom;
+
+            return *this;
+        }
+
+        /**
+         *  @brief Divide this complex number by a scalar
+         */
+        constexpr Complex &operator/=(float c) {
+            re_ /= c;
+            im_ /= c;
+
+            return *this;
+        }
+
+
+        // ---------------- Utility  ----------------
+        std::string toString(uint8_t percision = COMPLEX_DEFAULT_PRECISION) const;
+};
+
+} // cobalt::math::algebra

--- a/include/cobalt/math/algebra/complex/complex_ops.hpp
+++ b/include/cobalt/math/algebra/complex/complex_ops.hpp
@@ -1,0 +1,101 @@
+#pragma once
+
+#include "complex.hpp"
+
+namespace cobalt::math::algebra {
+// ---------------- Non-member Overloads ----------------
+
+inline Complex operator+(Complex lhs, const Complex &rhs) { lhs += rhs; return lhs; }
+inline Complex operator+(Complex lhs, float c) { lhs += c; return lhs; }
+inline Complex operator+(float c, Complex lhs) { lhs += c; return lhs; }
+
+inline Complex operator-(Complex lhs, const Complex &rhs) { lhs -= rhs; return lhs; }
+inline Complex operator-(Complex lhs, float c) { lhs -= c; return lhs; }
+inline Complex operator-(float c, Complex lhs) { lhs -= c; return lhs; }
+
+inline Complex operator*(Complex lhs, const Complex &rhs) { lhs *= rhs; return lhs; }
+inline Complex operator*(Complex lhs, float c) { lhs *= c; return lhs; }
+inline Complex operator*(float c, Complex lhs) { lhs *= c; return lhs; }
+
+inline Complex operator/(Complex lhs, const Complex &rhs) { lhs /= rhs; return lhs; }
+inline Complex operator/(Complex lhs, float c) { lhs /= c; return lhs; }
+inline Complex operator/(float c, Complex lhs) { lhs = (Complex::one() / lhs)*c; return lhs; }
+
+inline bool operator==(Complex lhs, const Complex &rhs) { 
+    if(static_cast<float>(lhs.real() - rhs.real()) > COMPLEX_EQUAL_THRESHOLD) { return false; }
+    if(static_cast<float>(lhs.real() - rhs.real()) > COMPLEX_EQUAL_THRESHOLD) { return false; }
+    return true;
+}
+inline bool operator==(Complex lhs, float c) { return ((static_cast<float>(lhs.real() - c) < COMPLEX_EQUAL_THRESHOLD) && (lhs.imag() < COMPLEX_ZERO_THRESHOLD)); }
+inline bool operator==(float c, Complex lhs) { return (lhs == c); }
+
+inline bool operator!=(Complex lhs, const Complex &rhs) { 
+    if(static_cast<float>(lhs.real() - rhs.real()) > COMPLEX_EQUAL_THRESHOLD) { return true; }
+    if(static_cast<float>(lhs.real() - rhs.real()) > COMPLEX_EQUAL_THRESHOLD) { return true; }
+    return false;
+}
+inline bool operator!=(Complex lhs, float c) { return ((static_cast<float>(lhs.real() - c) > COMPLEX_EQUAL_THRESHOLD) || (lhs.imag() > COMPLEX_ZERO_THRESHOLD)); }
+inline bool operator!=(float c, Complex lhs) { return (lhs != c); }
+
+
+// ---------------- Non-member Functions ----------------
+/**
+ *  @brief Get the norm/absolute value of a complex number
+ *  @return `|z|` The norm of the complex number
+ */
+constexpr inline float abs(const Complex &z) { return static_cast<float>(std::sqrt(z.real()*z.real() + z.imag()*z.imag())); }
+
+/**
+ *  @brief Get the square of the norm/absolute value of a complex number
+ *  @return `|z|²` The squared norm of the complex number
+ */
+constexpr inline float normSqr(const Complex &z) { return (z.real()*z.real() + z.imag()*z.imag()); }
+
+/**
+ *  @brief Get the argument/angle of a complex number
+ *  @return `∠z` The argument of the complex number
+ */
+constexpr inline float arg(const Complex &z) { return static_cast<float>(std::atan2(z.imag(), z.real())); }
+
+/**
+ *  @brief Get the conjugate of a complex number
+ *  @return `z̄` Conjugate of the compex number
+ */
+inline Complex conj(const Complex &z) { return Complex(z.real(), -z.imag()); }
+
+/**
+ *  @brief Get the multiplicative inverse of the complex number
+ *  @return `1/z` The inverse of the complex number
+ */
+inline Complex inv(const Complex &z) { 
+    float d = normSqr(z);
+    return Complex(z.real()/d, -z.imag()/d);
+ }
+
+ /**
+ *  @brief Get the exponential power of the complex number to e
+ *  @return `eᶻ` The exponentited complex number
+ */
+inline Complex exp(const Complex &z) {
+    return Complex::polar(static_cast<float>(std::pow(M_E, z.real())), z.imag());
+ }
+
+  /**
+ *  @brief Get the natural logarithm of the complex number  
+ *  @return `ln(z)` The natural log of the complex number
+ */
+inline Complex log(const Complex &z) {
+    return Complex(static_cast<float>(std::log(abs(z))), arg(z));
+
+} // cobalt::math::algebra
+
+
+  /**
+ *  @brief Get the n-th power of the complex number
+ *  @return `zⁿ` The n-th power of the complex number
+ */
+inline Complex pow(const Complex &z, float n) {
+    return Complex(static_cast<float>(std::pow(abs(z), n)), arg(z)*n);
+}
+
+} // cobalt::math::algebra

--- a/include/cobalt/math/algebra/complex/complex_ops.hpp
+++ b/include/cobalt/math/algebra/complex/complex_ops.hpp
@@ -95,7 +95,7 @@ inline Complex log(const Complex &z) {
  *  @return `zⁿ` The n-th power of the complex number
  */
 inline Complex pow(const Complex &z, float n) {
-    return Complex(static_cast<float>(std::pow(abs(z), n)), arg(z)*n);
+    return Complex::polar(static_cast<float>(std::pow(abs(z), n)), arg(z)*n);
 }
 
 } // cobalt::math::algebra

--- a/include/cobalt/math/algebra/complex/complex_ops.hpp
+++ b/include/cobalt/math/algebra/complex/complex_ops.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cmath>
+
 #include "complex.hpp"
 
 namespace cobalt::math::algebra {

--- a/include/cobalt/math/algebra/complex/complex_util.hpp
+++ b/include/cobalt/math/algebra/complex/complex_util.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <stdint.h>
+#include <string>
+#include <sstream>
+#include <iomanip>
+
+#include "complex.hpp"
+
+namespace cobalt::math::algebra {
+
+constexpr bool isZero(const Complex &z);
+constexpr bool isReal(const Complex &z);
+constexpr bool isImag(const Complex &z);
+
+
+// ---------------- Member Utility ----------------
+std::string Complex::toString(uint8_t percision) const {
+    std::ostringstream oss;
+    if(isZero(*this)) { oss << std::fixed << std::setprecision(percision) << 0          ; return oss.str(); }
+    if(isReal(*this)) { oss << std::fixed << std::setprecision(percision) << re_        ; return oss.str(); }
+    if(isImag(*this)) { oss << std::fixed << std::setprecision(percision) << im_ << "j" ; return oss.str(); }
+
+    oss << std::fixed << std::setprecision(percision) << re_;
+
+    oss << std::fixed << std::setprecision(percision) << ((im_ > 0.0f) ?" + " :" - ");
+
+    oss << std::fixed << std::setprecision(percision) << std::abs(im_) << "j";
+
+    return oss.str();
+}
+
+// ---------------- Checks ----------------
+/**
+ *  @brief Check if a complex number is zero (0 + 0j)
+ */
+constexpr bool isZero(const Complex &z) { 
+    if(static_cast<float>(std::abs(z.real())) > COMPLEX_ZERO_THRESHOLD) { return false; }
+    if(static_cast<float>(std::abs(z.imag())) > COMPLEX_ZERO_THRESHOLD) { return false; }
+    return true;
+}
+
+/**
+ *  @brief Check if a complex number is purely real
+ */
+constexpr bool isReal(const Complex &z) { 
+    if(static_cast<float>(std::abs(z.real())) < COMPLEX_ZERO_THRESHOLD) { return false; }
+    if(static_cast<float>(std::abs(z.imag())) > COMPLEX_ZERO_THRESHOLD) { return false; }
+    return true;
+}
+
+/**
+ *  @brief Check if a complex number is purely imaginary
+ */
+constexpr bool isImag(const Complex &z) { 
+    if(static_cast<float>(std::abs(z.real())) > COMPLEX_ZERO_THRESHOLD) { return false; }
+    if(static_cast<float>(std::abs(z.imag())) < COMPLEX_ZERO_THRESHOLD) { return false; }
+    return true;
+}
+    
+} // cobalt::math::algebra

--- a/include/cobalt/math/linear_algebra/linear_algebra.hpp
+++ b/include/cobalt/math/linear_algebra/linear_algebra.hpp
@@ -7,3 +7,5 @@
 
 // ----- Matrix -----
 #include "matrix/matrix.hpp"        // Core matrix definition
+#include "matrix/matrix_ops.hpp"    // -- Maxtrix arithmetic & math operation defintions
+#include "matrix/matrix_util.hpp"   // -- Maxtrix utility tool & algorithm defintions

--- a/include/cobalt/math/linear_algebra/vector/vector.hpp
+++ b/include/cobalt/math/linear_algebra/vector/vector.hpp
@@ -93,6 +93,18 @@ struct Vector{
             static constexpr Vector unitZ() noexcept { return Vector{static_cast<T>(0), static_cast<T>(0), static_cast<T>(1)}; }
         
 
+        /**
+         *  @brief Construct a vector from std::array.
+         */
+        static constexpr inline Vector fromArray(const std::array<T, N> &arr) {
+            Vector<N, T> v;
+            for(uint8_t i = 0; i < N; i++) {
+                v[i] = arr[i];
+            }
+
+            return v;
+        }
+
         // ---------------- Getters ----------------
         /**
          *  @brief Return the size of the vector.

--- a/include/cobalt/math/linear_algebra/vector/vector_util.hpp
+++ b/include/cobalt/math/linear_algebra/vector/vector_util.hpp
@@ -222,19 +222,6 @@ constexpr inline std::array<T, N> toArray(const Vector<N, T> &v) {
 }
 
 /**
- *  @brief Construct a vector from std::array.
- */
-template<uint8_t N, typename T = float>
-constexpr inline Vector<N, T> fromArray(const std::array<T, N> &arr) {  // TODO: Fix usage
-    Vector<N, T> v;
-    for(uint8_t i = 0; i < N; i++) {
-        v[i] = arr[i];
-    }
-
-    return v;
-}
-
-/**
  *  @brief Construct a skew-symmetric matrix(3x3)from a vector(3).
  *  @param v Vector to turn into a skew-symmetric matrix.
  */

--- a/include/cobalt/math/math.hpp
+++ b/include/cobalt/math/math.hpp
@@ -1,3 +1,4 @@
 #pragma once
 
 #include "linear_algebra/linear_algebra.hpp"    // Linear Algebra | Vectors, Matricies, Duals, etc.
+#include "algebra/algebra.hpp"                  // Algebra

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,13 +3,14 @@ add_executable(cobalt_tests
     sanity_test.cpp
 
     # ===== Math =====
-    #./math/linear_algebra/vector_test.cpp
-    #./math/linear_algebra/matrix_test.cpp
+    ./math/linear_algebra/vector_test.cpp
+    ./math/linear_algebra/matrix_test.cpp
+    ./math/linear_algebra/complex_vector_test.cpp
 
     ./math/algebra/complex_test.cpp
 
     # ===== Control =====
-    #./control/controller/pid_test.cpp
+    ./control/controller/pid_test.cpp
 )
 
 # Include paths

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,11 +3,13 @@ add_executable(cobalt_tests
     sanity_test.cpp
 
     # ===== Math =====
-    ./math/linear_algebra/vector_test.cpp
-    ./math/linear_algebra/matrix_test.cpp
+    #./math/linear_algebra/vector_test.cpp
+    #./math/linear_algebra/matrix_test.cpp
+
+    ./math/algebra/complex_test.cpp
 
     # ===== Control =====
-    ./control/controller/pid_test.cpp
+    #./control/controller/pid_test.cpp
 )
 
 # Include paths
@@ -22,7 +24,4 @@ target_link_libraries(cobalt_tests PRIVATE cobalt Catch2::Catch2WithMain)
 enable_testing()
 include(CTEST)
 include(CATCH)
-catch_discover_tests(cobalt_tests
-    REPORTER xml
-    OUTPUT_DIR ${CMAKE_BINARY_DIR}/Testing
-)
+catch_discover_tests(cobalt_tests)

--- a/tests/math/algebra/complex_test.cpp
+++ b/tests/math/algebra/complex_test.cpp
@@ -1,0 +1,68 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <cobalt/math/algebra/complex/complex.hpp>
+#include <cobalt/math/algebra/complex/complex_ops.hpp>
+#include <cobalt/math/algebra/complex/complex_util.hpp>
+
+using cobalt::math::algebra::Complex;
+
+TEST_CASE("Complex, construction & operations", "[complex]") {
+    Complex z(1, 1);
+    Complex x(3, -2);
+    Complex w;
+
+    REQUIRE(z.real() == Catch::Approx(1.0f));
+    REQUIRE(z.imag() == Catch::Approx(1.0f));
+
+    REQUIRE(x.real() == Catch::Approx(3.0f));
+    REQUIRE(x.imag() == Catch::Approx(-2.0f));
+
+    REQUIRE(w.real() == Catch::Approx(0.0f));
+    REQUIRE(w.imag() == Catch::Approx(0.0f));
+
+    z += x;
+
+    REQUIRE(z.real() == Catch::Approx(4.0f));
+    REQUIRE(z.imag() == Catch::Approx(-1.0f));
+
+    z *= 2;
+
+    REQUIRE(z.real() == Catch::Approx(8.0f));
+    REQUIRE(z.imag() == Catch::Approx(-2.0f));
+
+    z -= x;
+
+    REQUIRE(z.real() == Catch::Approx(5.0f));
+    REQUIRE(z.imag() == Catch::Approx(0.0f));
+
+}   
+
+TEST_CASE("Complex, arg/abs/conj", "[complex]") {
+    Complex z(1, 1);
+    Complex x(0, 4);
+
+    REQUIRE(abs(z) == Catch::Approx(std::sqrt(2)));
+    REQUIRE(arg(z) == Catch::Approx(M_PI_4));
+
+    REQUIRE(abs(x) == Catch::Approx(4));
+    REQUIRE(arg(x) == Catch::Approx(M_PI_2));
+
+    z = conj(z);
+
+    REQUIRE(abs(z) == Catch::Approx(std::sqrt(2)));
+    REQUIRE(arg(z) == Catch::Approx(-M_PI_4));
+}   
+
+TEST_CASE("Complex, toString", "[complex]") {
+    Complex z(12, -3);
+    Complex x(0, -1.5);
+    Complex w(3, 0);
+    Complex y(0, 0);
+
+    REQUIRE(z.toString() == "12.000 - 3.000j");
+    REQUIRE(x.toString() == "-1.500j");
+    REQUIRE(w.toString() == "3.000");
+    REQUIRE(y.toString() == "0");
+
+}   

--- a/tests/math/algebra/complex_test.cpp
+++ b/tests/math/algebra/complex_test.cpp
@@ -36,6 +36,12 @@ TEST_CASE("Complex, construction & operations", "[complex]") {
     REQUIRE(z.real() == Catch::Approx(5.0f));
     REQUIRE(z.imag() == Catch::Approx(0.0f));
 
+    z += Complex::oneIm();
+    z = -z;
+
+    REQUIRE(z.real() == Catch::Approx(-5.0f));
+    REQUIRE(z.imag() == Catch::Approx(-1.0f));
+
 }   
 
 TEST_CASE("Complex, arg/abs/conj", "[complex]") {
@@ -52,6 +58,24 @@ TEST_CASE("Complex, arg/abs/conj", "[complex]") {
 
     REQUIRE(abs(z) == Catch::Approx(std::sqrt(2)));
     REQUIRE(arg(z) == Catch::Approx(-M_PI_4));
+}   
+
+TEST_CASE("Complex, exp, log, pow", "[complex]") {
+    Complex z(1, 1);
+    Complex w(0, 1);
+
+    REQUIRE(exp(z).real() == Catch::Approx(1.4686939f).margin(1e-6));
+    REQUIRE(exp(z).imag() == Catch::Approx(2.28735528f).margin(1e-6));
+
+    REQUIRE(log(z).real() == Catch::Approx(0.346573f).margin(1e-6));
+    REQUIRE(log(z).imag() == Catch::Approx(0.7853981f).margin(1e-6));
+
+    REQUIRE(pow(w, 2).real() == Catch::Approx(-1.0f).margin(1e-6));
+    REQUIRE(pow(w, 2).imag() == Catch::Approx(0.0f).margin(1e-6));
+    REQUIRE(pow(w, 3).real() == Catch::Approx(0.0f).margin(1e-6));
+    REQUIRE(pow(w, 3).imag() == Catch::Approx(-1.0f).margin(1e-6));
+    REQUIRE(pow(w, 4).real() == Catch::Approx(1.0f).margin(1e-6));
+    REQUIRE(pow(w, 4).imag() == Catch::Approx(0.0f).margin(1e-6));
 }   
 
 TEST_CASE("Complex, toString", "[complex]") {

--- a/tests/math/linear_algebra/complex_vector_test.cpp
+++ b/tests/math/linear_algebra/complex_vector_test.cpp
@@ -1,0 +1,88 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <cobalt/math/linear_algebra/vector/vector.hpp>
+#include <cobalt/math/linear_algebra/vector/vector_ops.hpp>
+#include <cobalt/math/linear_algebra/vector/vector_util.hpp>
+
+#include <cobalt/math/algebra/complex/complex.hpp>
+#include <cobalt/math/algebra/complex/complex_ops.hpp>
+
+using cobalt::math::linear_algebra::Vector;
+using cobalt::math::algebra::Complex;
+
+TEST_CASE("Compelx-Vector, default construction", "[complex-vector]") {
+    Vector<3, Complex> v;
+
+    REQUIRE(v[0].real() == Catch::Approx(0.0f).margin(1e-6));
+    REQUIRE(v[0].imag() == Catch::Approx(0.0f).margin(1e-6));
+
+    REQUIRE(v[1].real() == Catch::Approx(0.0f).margin(1e-6));
+    REQUIRE(v[1].imag() == Catch::Approx(0.0f).margin(1e-6));
+
+    REQUIRE(v[2].real() == Catch::Approx(0.0f).margin(1e-6));
+    REQUIRE(v[2].imag() == Catch::Approx(0.0f).margin(1e-6));
+}   
+
+TEST_CASE("Compelx-Vector, constructor", "[complex-vector]") {
+    Vector<3, Complex> v(Complex(1.0f, 1.0f), Complex(4.0f, -3.0f), Complex(0.0f, -2.3f));
+
+    REQUIRE(v[0].real() == Catch::Approx(1.0f).margin(1e-6));
+    REQUIRE(v[0].imag() == Catch::Approx(1.0f).margin(1e-6));
+
+    REQUIRE(v[1].real() == Catch::Approx(4.0f).margin(1e-6));
+    REQUIRE(v[1].imag() == Catch::Approx(-3.0f).margin(1e-6));
+
+    REQUIRE(v[2].real() == Catch::Approx(0.0f).margin(1e-6));
+    REQUIRE(v[2].imag() == Catch::Approx(-2.3f).margin(1e-6));
+}
+
+TEST_CASE("Compelx-Vector, basic operations", "[complex-vector]") {
+    Vector<3, Complex> v(Complex(1.0f, 1.0f), Complex(4.0f, -3.0f), Complex(0.0f, -2.3f));
+    Vector<3, Complex> u(Complex(1.5f, -4.0f), Complex(2.0f, -9.5f), Complex(3.0f, 0.0f));
+    Vector<3, Complex> w = v + u;
+
+    REQUIRE(w[0].real() == Catch::Approx(2.5f).margin(1e-6));
+    REQUIRE(w[0].imag() == Catch::Approx(-3.0f).margin(1e-6));
+    REQUIRE(w[1].real() == Catch::Approx(6.0f).margin(1e-6));
+    REQUIRE(w[1].imag() == Catch::Approx(-12.5f).margin(1e-6));
+    REQUIRE(w[2].real() == Catch::Approx(3.0f).margin(1e-6));
+    REQUIRE(w[2].imag() == Catch::Approx(-2.3f).margin(1e-6));
+
+    w = v - u;
+
+    REQUIRE(w[0].real() == Catch::Approx(-0.5f).margin(1e-6));
+    REQUIRE(w[0].imag() == Catch::Approx(5.0f).margin(1e-6));
+    REQUIRE(w[1].real() == Catch::Approx(2.0f).margin(1e-6));
+    REQUIRE(w[1].imag() == Catch::Approx(6.5f).margin(1e-6));
+    REQUIRE(w[2].real() == Catch::Approx(-3.0f).margin(1e-6));
+    REQUIRE(w[2].imag() == Catch::Approx(-2.3f).margin(1e-6));
+
+    CAPTURE(v[0].real());
+    CAPTURE(v[0].imag());
+
+    CAPTURE((v*3)[0].real());
+    CAPTURE((v*3)[0].imag());
+
+    w = v*3;
+
+    REQUIRE(w[0].real() == Catch::Approx(3.0f).margin(1e-6));
+    REQUIRE(w[0].imag() == Catch::Approx(3.0f).margin(1e-6));
+    REQUIRE(w[1].real() == Catch::Approx(12.0f).margin(1e-6));
+    REQUIRE(w[1].imag() == Catch::Approx(-9.0f).margin(1e-6));
+    REQUIRE(w[2].real() == Catch::Approx(0.0f).margin(1e-6));
+    REQUIRE(w[2].imag() == Catch::Approx(-6.9f).margin(1e-6));
+}
+
+TEST_CASE("Compelx-Vector, misc. ops", "[complex-vector]") {
+    Vector<3, Complex> v(Complex(1.0f, 1.0f), Complex(4.0f, -3.0f), Complex(0.0f, -2.3f));
+
+    REQUIRE(v[0].real() == Catch::Approx(1.0f).margin(1e-6));
+    REQUIRE(v[0].imag() == Catch::Approx(1.0f).margin(1e-6));
+
+    REQUIRE(v[1].real() == Catch::Approx(4.0f).margin(1e-6));
+    REQUIRE(v[1].imag() == Catch::Approx(-3.0f).margin(1e-6));
+
+    REQUIRE(v[2].real() == Catch::Approx(0.0f).margin(1e-6));
+    REQUIRE(v[2].imag() == Catch::Approx(-2.3f).margin(1e-6));
+}

--- a/tests/math/linear_algebra/vector_test.cpp
+++ b/tests/math/linear_algebra/vector_test.cpp
@@ -1,6 +1,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 
+#include <cmath>
+
 #include <cobalt/math/linear_algebra/vector/vector.hpp>
 #include <cobalt/math/linear_algebra/vector/vector_ops.hpp>
 #include <cobalt/math/linear_algebra/vector/vector_util.hpp>
@@ -35,7 +37,7 @@ TEST_CASE("Vector, brace construction", "[vector]") {
 TEST_CASE("Vector, from/to array", "[vector]") {
     std::array<float, 4> arr = {1.0f, 2.0f, 10.0f, -2.0f};
 
-    Vector<4> v = cobalt::math::linear_algebra::fromArray<4>(arr);
+    Vector<4> v = Vector<4>::fromArray(arr);
 
     REQUIRE(v[0] == Catch::Approx(1.0f));
     REQUIRE(v[1] == Catch::Approx(2.0f));


### PR DESCRIPTION
### Overview
The PR introduces the initial `Complex` implementation into `cobalt::math::algebra`. It provides a Complex
### Key Features
* Complex
  - Overloads for basic operations (+, -, *, /, ==, !=)
  - Utility operstions (`abs()`, `arg()`, `conj()`, `normSqr()`, `inv()`)
  - Static factories for zero, unitary and polar defintions
* Vector<Complex>
  - Most vector operations and utiltiy work seemlessly with Complex elements with further test needed to confirm 100% compatibility
   
### Tests 
- Unit tests on all tested Vector operations with Complex elements work
  
### Notes
* No full-proof support of Complex Vectors or Complex Matricies. Some operations are compatible but some may not be.