### PR TITLE
feat(hal): Add initial I2C abstraction for Arduino and ESP-IDF frameworks

### DIFF
--- a/include/cobalt/hal/hal.hpp
+++ b/include/cobalt/hal/hal.hpp
@@ -4,11 +4,15 @@
 #include "gpio/gpio_arduino.hpp"    // -- Arudino GPIO implementation class
 #include "gpio/gpio_espidf.hpp"     // -- ESPIDF GPIO implementation class
 
+#include "i2c/i2c_base.hpp"       // Base I2C virtual class
+#include "i2c/i2c_arduino.hpp"    // -- Arudino I2C implementation class
+
 
 namespace cobalt::hal {
-    #ifdef ARDUINO
+    #if defined(ARDUINO)
         using GPIO = GPIOArduino;
-    #elifdef IDF_VER
+        using I2C = I2CArduino;
+    #elif defined(IDF_VER)
         using GPIO = GPIOESPIDF;
     #endif
 }

--- a/include/cobalt/hal/i2c/i2c_arduino.hpp
+++ b/include/cobalt/hal/i2c/i2c_arduino.hpp
@@ -4,7 +4,7 @@
 
 #include "i2c_base.hpp"
 
-#if defined ARDUINO
+#if defined(ARDUINO)
 #include <Wire.h>
 
 namespace cobalt::hal {
@@ -31,8 +31,8 @@ class I2CArduino : public I2CBase {
         // ---------------- Constructors ----------------
         /**
          * @brief Constructor for Arduino I2C implementation layer
-         * @param sdaPin SDA pin number of the arduino board
-         * @param sclPin SCL pin number of the arduino baord
+         * @param sdaPin SDA pin number
+         * @param sclPin SCL pin number
          * 
          * @note Leave pin definitions empty if on an Arduino UNO board.
          */
@@ -40,9 +40,9 @@ class I2CArduino : public I2CBase {
 
         // ----------------  Arduino I2C Member Functions ----------------
 
-        bool init(uint8_t address, uint8_t bus, I2CMode mode, uint32_t frequency) override;
-        bool write(uint8_t address, const uint8_t *wBuff, size_t len) override;
-        bool read(uint8_t address, uint8_t *rBuff, size_t len) override;
+        bool init(uint8_t bus = I2C_ARDUINO_DEFAULT_BUS, I2CMode mode = I2C_ARDUINO_DEFAULT_MODE, uint32_t frequency = I2C_ARDUINO_DEFAULT_FREQUENCY) override;
+        bool write(uint8_t address, const uint8_t *wBuff, size_t len = 1) override;
+        bool read(uint8_t address, uint8_t *rBuff, size_t len = 1) override;
         bool writeRead(uint8_t address, const uint8_t *wBuff, size_t writeLen, uint8_t *rBuff, size_t readLen) override;
         bool writeReg(uint8_t address, uint8_t regAddr, uint8_t wBuff) override;
         bool readReg(uint8_t address, uint8_t regAddr, uint8_t *rBuff) override;

--- a/include/cobalt/hal/i2c/i2c_arduino.hpp
+++ b/include/cobalt/hal/i2c/i2c_arduino.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "i2c_base.hpp"
+
+namespace cobalt::hal {
+
+constexpr uint8_t I2C_ARDUINO_DEFAULT_PORT = 0; 
+constexpr I2CMode I2C_ARDUINO_DEFAULT_MODE = I2CMode::Master;
+constexpr uint32_t I2C_ARDUINO_DEFAULT_FREQUENCY = 100000;
+
+
+// --------------------------------------
+//      Arduino I2C Implementation    
+// --------------------------------------
+
+class I2CArduino : public I2CBase {
+    private:
+        uint8_t pinSDA_;
+        uint8_t pinSCL_;
+
+    public:
+        // ---------------- Constructors ----------------
+        /**
+         * @brief Constructor for Arduino I2C implementation layer
+         * @param sdaPin SDA pin number of the arduino board
+         * @param sclPin SCL
+         */
+        explicit I2CArduino(uint8_t sdaPin, uint8_t sclPin) : pinSDA_(sdaPin), pinSCL_(sclPin) {}
+
+        bool init(uint8_t address, uint8_t port, I2CMode mode, uint32_t frequency) override;
+        bool write(uint8_t address, uint8_t *wBuff, size_t len) override;
+        bool read(uint8_t address, uint8_t *rBuff, size_t len) override;
+        bool request(uint8_t address, uint8_t *wBuff, uint8_t *rBuff, size_t readLen) override;
+};
+
+} // cobalt::hal

--- a/include/cobalt/hal/i2c/i2c_arduino.hpp
+++ b/include/cobalt/hal/i2c/i2c_arduino.hpp
@@ -6,6 +6,9 @@
 
 namespace cobalt::hal {
 
+constexpr uint8_t I2C_ARDUINO_DEFAULT_SDA = 4; 
+constexpr uint8_t I2C_ARDUINO_DEFAULT_SCL = 5; 
+
 constexpr uint8_t I2C_ARDUINO_DEFAULT_PORT = 0; 
 constexpr I2CMode I2C_ARDUINO_DEFAULT_MODE = I2CMode::Master;
 constexpr uint32_t I2C_ARDUINO_DEFAULT_FREQUENCY = 100000;
@@ -25,14 +28,20 @@ class I2CArduino : public I2CBase {
         /**
          * @brief Constructor for Arduino I2C implementation layer
          * @param sdaPin SDA pin number of the arduino board
-         * @param sclPin SCL
+         * @param sclPin SCL pin number of the arduino baord
+         * 
+         * @note Leave pin definitions empty if on an Arduino UNO board.
          */
-        explicit I2CArduino(uint8_t sdaPin, uint8_t sclPin) : pinSDA_(sdaPin), pinSCL_(sclPin) {}
+        explicit I2CArduino(uint8_t sdaPin = I2C_ARDUINO_DEFAULT_SDA, uint8_t sclPin = I2C_ARDUINO_DEFAULT_SCL) : pinSDA_(sdaPin), pinSCL_(sclPin) {}
 
-        bool init(uint8_t address, uint8_t port, I2CMode mode, uint32_t frequency) override;
-        bool write(uint8_t address, uint8_t *wBuff, size_t len) override;
-        bool read(uint8_t address, uint8_t *rBuff, size_t len) override;
-        bool request(uint8_t address, uint8_t *wBuff, uint8_t *rBuff, size_t readLen) override;
+        // ----------------  Arduino I2C Member Functions ----------------
+
+        bool init(uint8_t address, uint8_t bus, I2CMode mode, uint32_t frequency) override;
+        bool write(uint8_t address, uint8_t *wBuff, size_t len = 1) override;
+        bool read(uint8_t address, uint8_t *rBuff, size_t len = 1) override;
+        bool writeReg(uint8_t address, uint8_t regAddr, uint8_t *wBuff, size_t len = 1) override;
+        bool readReg(uint8_t address, uint8_t regAddr, uint8_t *rBuff, size_t len = 1) override;
+        bool writeRead(uint8_t address, uint8_t *wBuff, uint8_t *rBuff, size_t readLen) override;
 };
 
 } // cobalt::hal

--- a/include/cobalt/hal/i2c/i2c_arduino.hpp
+++ b/include/cobalt/hal/i2c/i2c_arduino.hpp
@@ -4,12 +4,15 @@
 
 #include "i2c_base.hpp"
 
+#if defined ARDUINO
+#include <Wire.h>
+
 namespace cobalt::hal {
 
 constexpr uint8_t I2C_ARDUINO_DEFAULT_SDA = 4; 
 constexpr uint8_t I2C_ARDUINO_DEFAULT_SCL = 5; 
 
-constexpr uint8_t I2C_ARDUINO_DEFAULT_PORT = 0; 
+constexpr uint8_t I2C_ARDUINO_DEFAULT_BUS = 0; 
 constexpr I2CMode I2C_ARDUINO_DEFAULT_MODE = I2CMode::Master;
 constexpr uint32_t I2C_ARDUINO_DEFAULT_FREQUENCY = 100000;
 
@@ -22,6 +25,7 @@ class I2CArduino : public I2CBase {
     private:
         uint8_t pinSDA_;
         uint8_t pinSCL_;
+        TwoWire *wire_ = nullptr;
 
     public:
         // ---------------- Constructors ----------------
@@ -37,11 +41,13 @@ class I2CArduino : public I2CBase {
         // ----------------  Arduino I2C Member Functions ----------------
 
         bool init(uint8_t address, uint8_t bus, I2CMode mode, uint32_t frequency) override;
-        bool write(uint8_t address, uint8_t *wBuff, size_t len = 1) override;
-        bool read(uint8_t address, uint8_t *rBuff, size_t len = 1) override;
-        bool writeReg(uint8_t address, uint8_t regAddr, uint8_t *wBuff, size_t len = 1) override;
-        bool readReg(uint8_t address, uint8_t regAddr, uint8_t *rBuff, size_t len = 1) override;
-        bool writeRead(uint8_t address, uint8_t *wBuff, uint8_t *rBuff, size_t readLen) override;
+        bool write(uint8_t address, const uint8_t *wBuff, size_t len) override;
+        bool read(uint8_t address, uint8_t *rBuff, size_t len) override;
+        bool writeRead(uint8_t address, const uint8_t *wBuff, size_t writeLen, uint8_t *rBuff, size_t readLen) override;
+        bool writeReg(uint8_t address, uint8_t regAddr, uint8_t wBuff) override;
+        bool readReg(uint8_t address, uint8_t regAddr, uint8_t *rBuff) override;
 };
 
 } // cobalt::hal
+
+#endif

--- a/include/cobalt/hal/i2c/i2c_base.hpp
+++ b/include/cobalt/hal/i2c/i2c_base.hpp
@@ -19,7 +19,7 @@ class I2CBase {
     public:
         virtual ~I2CBase() = default;
 
-        virtual bool init(uint8_t address, uint8_t bus, I2CMode mode, uint32_t frequency) = 0;
+        virtual bool init(uint8_t bus, I2CMode mode, uint32_t frequency) = 0;
         virtual bool write(uint8_t address, const uint8_t *wBuff, size_t len) = 0;
         virtual bool read(uint8_t address, uint8_t *rBuff, size_t len) = 0;
         virtual bool writeRead(uint8_t address, const uint8_t *wBuff, size_t writeLen, uint8_t *rBuff, size_t readLen) = 0;

--- a/include/cobalt/hal/i2c/i2c_base.hpp
+++ b/include/cobalt/hal/i2c/i2c_base.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
 
 namespace cobalt::hal {
@@ -19,11 +20,11 @@ class I2CBase {
         virtual ~I2CBase() = default;
 
         virtual bool init(uint8_t address, uint8_t bus, I2CMode mode, uint32_t frequency) = 0;
-        virtual bool write(uint8_t address, uint8_t *wBuff, size_t len) = 0;
+        virtual bool write(uint8_t address, const uint8_t *wBuff, size_t len) = 0;
         virtual bool read(uint8_t address, uint8_t *rBuff, size_t len) = 0;
-        virtual bool writeReg(uint8_t address, uint8_t regAddr, uint8_t *wBuff, size_t len) = 0;
-        virtual bool readReg(uint8_t address, uint8_t regAddr, uint8_t *rBuff, size_t len) = 0;
-        virtual bool writeRead(uint8_t address, uint8_t *wBuff, uint8_t *rBuff, size_t readLen) = 0;
+        virtual bool writeRead(uint8_t address, const uint8_t *wBuff, size_t writeLen, uint8_t *rBuff, size_t readLen) = 0;
+        virtual bool writeReg(uint8_t address, uint8_t regAddr, uint8_t wBuff) = 0;
+        virtual bool readReg(uint8_t address, uint8_t regAddr, uint8_t *rBuff) = 0;
 };
 
 } // cobalt::hal

--- a/include/cobalt/hal/i2c/i2c_base.hpp
+++ b/include/cobalt/hal/i2c/i2c_base.hpp
@@ -18,10 +18,12 @@ class I2CBase {
     public:
         virtual ~I2CBase() = default;
 
-        virtual bool init(uint8_t address, uint8_t port, I2CMode mode, uint32_t frequency) = 0;
+        virtual bool init(uint8_t address, uint8_t bus, I2CMode mode, uint32_t frequency) = 0;
         virtual bool write(uint8_t address, uint8_t *wBuff, size_t len) = 0;
         virtual bool read(uint8_t address, uint8_t *rBuff, size_t len) = 0;
-        virtual bool request(uint8_t address, uint8_t *wBuff, uint8_t *rBuff, size_t readLen) = 0;
+        virtual bool writeReg(uint8_t address, uint8_t regAddr, uint8_t *wBuff, size_t len) = 0;
+        virtual bool readReg(uint8_t address, uint8_t regAddr, uint8_t *rBuff, size_t len) = 0;
+        virtual bool writeRead(uint8_t address, uint8_t *wBuff, uint8_t *rBuff, size_t readLen) = 0;
 };
 
 } // cobalt::hal

--- a/include/cobalt/hal/i2c/i2c_base.hpp
+++ b/include/cobalt/hal/i2c/i2c_base.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace cobalt::hal {
+
+enum class I2CMode {
+    Master,
+    Slave
+};
+
+// --------------------------------------
+//      Base I2C Implementation    
+// --------------------------------------
+
+class I2CBase {
+    protected:
+    public:
+        virtual ~I2CBase() = default;
+
+        virtual bool init(uint8_t address, uint8_t port, I2CMode mode, uint32_t frequency) = 0;
+        virtual bool write(uint8_t address, uint8_t *wBuff, size_t len) = 0;
+        virtual bool read(uint8_t address, uint8_t *rBuff, size_t len) = 0;
+        virtual bool request(uint8_t address, uint8_t *wBuff, uint8_t *rBuff, size_t readLen) = 0;
+};
+
+} // cobalt::hal

--- a/include/cobalt/hal/i2c/i2c_espidf.hpp
+++ b/include/cobalt/hal/i2c/i2c_espidf.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#pragma once
+
+#include <stdint.h>
+
+#include "i2c_base.hpp"
+
+#if defined(IDF_VER)
+#include <driver/i2c.h>
+
+namespace cobalt::hal {
+
+constexpr uint8_t I2C_ESPIDF_DEFAULT_BUS = 0; 
+constexpr I2CMode I2C_ESPIDF_DEFAULT_MODE = I2CMode::Master;
+constexpr uint32_t I2C_ESPIDF_DEFAULT_FREQUENCY = 100000;
+
+
+// --------------------------------------
+//      ESP-IDF I2C Implementation    
+// --------------------------------------
+
+class I2CESPIDF : public I2CBase {
+    private:
+        uint8_t pinSDA_;
+        uint8_t pinSCL_;
+        i2c_port_t port_;
+        bool isInitialized_;
+
+
+    public:
+        // ---------------- Constructors ----------------
+        /**
+         * @brief Constructor for ESP-IDF I2C implementation layer
+         * @param sdaPin SDA pin number
+         * @param sclPin SCL pin number
+         */
+        explicit I2CESPIDF(uint8_t sdaPin, uint8_t sclPin) : pinSDA_(sdaPin), pinSCL_(sclPin), port_(static_cast<i2c_port_t>(I2C_ESPIDF_DEFAULT_BUS)), isInitialized_(false) {}
+
+        ~I2CESPIDF() { if(isInitialized_) { i2c_driver_delete(port_); }}
+
+        // ----------------  ESP-IDF I2C Member Functions ----------------
+
+        bool init(uint8_t bus = I2C_ESPIDF_DEFAULT_BUS, I2CMode mode = I2C_ESPIDF_DEFAULT_MODE, uint32_t frequency = I2C_ESPIDF_DEFAULT_FREQUENCY) override;
+        bool write(uint8_t address, const uint8_t *wBuff, size_t len = 1) override;
+        bool read(uint8_t address, uint8_t *rBuff, size_t len = 1) override;
+        bool writeRead(uint8_t address, const uint8_t *wBuff, size_t writeLen, uint8_t *rBuff, size_t readLen) override;
+        bool writeReg(uint8_t address, uint8_t regAddr, uint8_t wBuff) override;
+        bool readReg(uint8_t address, uint8_t regAddr, uint8_t *rBuff) override;
+};
+
+} // cobalt::hal
+
+#endif

--- a/src/hal/i2c/i2c_arduino.cpp
+++ b/src/hal/i2c/i2c_arduino.cpp
@@ -1,0 +1,6 @@
+#include "cobalt/hal/i2c/i2c_base.hpp"
+
+
+bool init(uint8_t address, uint8_t port, I2CMode mode, uint32_t frequency) {
+    
+}

--- a/src/hal/i2c/i2c_arduino.cpp
+++ b/src/hal/i2c/i2c_arduino.cpp
@@ -5,13 +5,12 @@
 
 /**
 * @brief Initialize to start communication with the I2C Interface
-* @param address I2C Address of the device
 * @param bus I2C Bus to access. 0 for Arduino UNO boards and 0 or 1 for ESP boards.
 * @param mod I2C mode to operate in. Master or Slave
 * @param frequency I2C frequency to communicate
 * @return `true` if the initialization was successful, `false` otherwise
 */
-bool cobalt::hal::I2CArduino::init(uint8_t address, uint8_t bus = I2C_ARDUINO_DEFAULT_BUS, cobalt::hal::I2CMode mode = I2C_ARDUINO_DEFAULT_MODE, uint32_t frequency = I2C_ARDUINO_DEFAULT_FREQUENCY) {
+bool cobalt::hal::I2CArduino::init(uint8_t bus, cobalt::hal::I2CMode mode, uint32_t frequency) {
     #if defined(ESP32)
         switch(bus) {
             case(0): {
@@ -48,7 +47,7 @@ bool cobalt::hal::I2CArduino::init(uint8_t address, uint8_t bus = I2C_ARDUINO_DE
 * @param len Length of `wBuff` to write. (defaults to 1 byte)
 * @return `true` if the write was successful, `false` otherwise
 */
-bool cobalt::hal::I2CArduino::write(uint8_t address, const uint8_t *wBuff, size_t len = 1) {
+bool cobalt::hal::I2CArduino::write(uint8_t address, const uint8_t *wBuff, size_t len) {
     wire_->beginTransmission(address);
     size_t writtenBytes = wire_->write(wBuff, len);
     uint8_t result = wire_->endTransmission();
@@ -63,7 +62,7 @@ bool cobalt::hal::I2CArduino::write(uint8_t address, const uint8_t *wBuff, size_
 * @param len Length of data to read into `rBuff`. (defaults to 1 byte)
 * @return `true` if the read was successful, `false` otherwise
 */
-bool cobalt::hal::I2CArduino::read(uint8_t address, uint8_t *rBuff, size_t len = 1) {
+bool cobalt::hal::I2CArduino::read(uint8_t address, uint8_t *rBuff, size_t len) {
     size_t readBytes = wire_->requestFrom(address, len);
     if(readBytes != len) { return false; }
 

--- a/src/hal/i2c/i2c_arduino.cpp
+++ b/src/hal/i2c/i2c_arduino.cpp
@@ -1,6 +1,9 @@
-#include "cobalt/hal/i2c/i2c_base.hpp"
+#include "cobalt/hal/i2c/i2c_arduino.hpp"
 
+/**
+* @brief Initialize to start communication with the I2C Interface
+* @param address Address of the device
+*/
+bool cobalt::hal::I2CArduino::init(uint8_t address, uint8_t bus, cobalt::hal::I2CMode mode, uint32_t frequency) {
 
-bool init(uint8_t address, uint8_t port, I2CMode mode, uint32_t frequency) {
-    
 }

--- a/src/hal/i2c/i2c_arduino.cpp
+++ b/src/hal/i2c/i2c_arduino.cpp
@@ -1,9 +1,117 @@
 #include "cobalt/hal/i2c/i2c_arduino.hpp"
 
+
+#if defined(ARDUINO)
+
 /**
 * @brief Initialize to start communication with the I2C Interface
-* @param address Address of the device
+* @param address I2C Address of the device
+* @param bus I2C Bus to access. 0 for Arduino UNO boards and 0 or 1 for ESP boards.
+* @param mod I2C mode to operate in. Master or Slave
+* @param frequency I2C frequency to communicate
+* @return `true` if the initialization was successful, `false` otherwise
 */
-bool cobalt::hal::I2CArduino::init(uint8_t address, uint8_t bus, cobalt::hal::I2CMode mode, uint32_t frequency) {
+bool cobalt::hal::I2CArduino::init(uint8_t address, uint8_t bus = I2C_ARDUINO_DEFAULT_BUS, cobalt::hal::I2CMode mode = I2C_ARDUINO_DEFAULT_MODE, uint32_t frequency = I2C_ARDUINO_DEFAULT_FREQUENCY) {
+    #if defined(ESP32)
+        switch(bus) {
+            case(0): {
+                wire_ = &Wire;              // bus-0
+                break;
+            }
+            case(1): {
+                static TwoWire Wire1(1);    // bus-1
+                wire_ = &Wire1;
+                break;
+            }
+            default:
+                return false;               // Invalid Bus
+        }
 
+        wire_->begin(pinSDA_, pinSCL_, frequency);
+
+    #elif defined(ARDUINO_AVR_UNO)
+        if(bus != 0) { return 0;}
+
+        wire_ = &Wire;
+        wire_->begin();
+
+    #endif
+
+    wire_->setClock(frequency);
+    return true;
 }
+
+/**
+* @brief Write the buffer data to the I2C device
+* @param address I2C Address of the device
+* @param wBuff Data buffer to write from
+* @param len Length of `wBuff` to write. (defaults to 1 byte)
+* @return `true` if the write was successful, `false` otherwise
+*/
+bool cobalt::hal::I2CArduino::write(uint8_t address, const uint8_t *wBuff, size_t len = 1) {
+    wire_->beginTransmission(address);
+    size_t writtenBytes = wire_->write(wBuff, len);
+    uint8_t result = wire_->endTransmission();
+
+    return ((result == 0) && (writtenBytes == len));
+}
+
+/**
+* @brief Read the I2C data to the buffer
+* @param address I2C Address of the device
+* @param rBuff Data buffer to read into
+* @param len Length of data to read into `rBuff`. (defaults to 1 byte)
+* @return `true` if the read was successful, `false` otherwise
+*/
+bool cobalt::hal::I2CArduino::read(uint8_t address, uint8_t *rBuff, size_t len = 1) {
+    size_t readBytes = wire_->requestFrom(address, len);
+    if(readBytes != len) { return false; }
+
+    for(size_t i = 0; i < len; i++) {
+        if(wire_->available()) { rBuff[i] = wire_->read(); }
+        else { return false; } 
+    }
+
+    return true;
+}
+
+/**
+* @brief Write to and then immediately read from the I2C device
+* @param address I2C Address of the device
+* @param wBuff Data buffer to read into
+* @param writeLen Length of `wBuff` to write.
+* @param rBuff Data buffer to read into
+* @param readLen Length of data to read into `rBuff`.
+* @return `true` if the write-read was successful, `false` otherwise
+*/
+bool cobalt::hal::I2CArduino::writeRead(uint8_t address, const uint8_t *wBuff, size_t writeLen, uint8_t *rBuff, size_t readLen) {
+    if(!write(address, wBuff, writeLen)) { return false; }
+    return read(address, rBuff, readLen);
+}
+
+/**
+* @brief Write 1 byte to the I2C device's register from the buffer
+* @param address I2C Address of the device
+* @param regAddr I2C Device's register to read
+* @param wBuff Data buffer to write from
+* @return `true` if the register write was successful, `false` otherwise
+*/
+bool cobalt::hal::I2CArduino::writeReg(uint8_t address, uint8_t regAddr, uint8_t wBuff) {
+    uint8_t buff[2] = { regAddr, wBuff };
+    return write(address, buff, 2);
+}
+
+/**
+* @brief Read 1 byte from the I2C device's register to the buffer
+* @param address I2C Address of the device
+* @param regAddr I2C Device's register to read
+* @param rBuff Data buffer to read into
+* @return `true` if the register read was successful, `false` otherwise
+*/
+bool cobalt::hal::I2CArduino::readReg(uint8_t address, uint8_t regAddr, uint8_t *rBuff) {
+    uint8_t buff[1] = { regAddr };
+    if(!write(address, buff)) { return false; }
+    return read(address, rBuff);
+}
+
+#endif

--- a/src/hal/i2c/i2c_espidf.cpp
+++ b/src/hal/i2c/i2c_espidf.cpp
@@ -1,0 +1,147 @@
+#include "cobalt/hal/i2c/i2c_espidf.hpp"
+
+#if defined(IDF_VER)
+
+/**
+* @brief Initialize to start communication with the I2C Interface
+* @param bus I2C Bus to access.
+* @param mod I2C mode to operate in. Master or Slave
+* @param frequency I2C frequency to communicate
+* @return `true` if the initialization was successful, `false` otherwise
+*/
+bool cobalt::hal::I2CESPIDF::init(uint8_t bus, cobalt::hal::I2CMode mode, uint32_t frequency) {
+    switch(bus) {
+        case(0) : { port_ = I2C_NUM_0; break; }
+        case(1) : { port_ = I2C_NUM_1; break; }
+        default : { return false; }
+    }
+
+    i2c_config_t conf{
+        .mode = (mode == cobalt::hal::I2CMode::Master) ?I2C_MODE_MASTER :I2C_MODE_SLAVE,
+        .sda_io_num = pinSDA_,
+        .scl_io_num = pinSCL_,
+        .sda_pullup_en = GPIO_PULLUP_ENABLE,
+        .scl_pullup_en = GPIO_PULLUP_ENABLE,
+    };
+
+    if(mode == cobalt::hal::I2CMode::Master) {
+        conf.master.clk_speed = frequency;
+    }
+
+    i2c_param_config(port_, &conf);
+
+    i2c_driver_install(port_, ((mode == cobalt::hal::I2CMode::Master) ?I2C_MODE_MASTER :I2C_MODE_SLAVE), 0, 0, 0);
+    isInitialized_ = true;
+
+    return true;
+}
+
+/**
+* @brief Write the buffer data to the I2C device
+* @param address I2C Address of the device
+* @param wBuff Data buffer to write from
+* @param len Length of `wBuff` to write. (defaults to 1 byte)
+* @return `true` if the write was successful, `false` otherwise
+*/
+bool cobalt::hal::I2CESPIDF::write(uint8_t address, const uint8_t *wBuff, size_t len) {
+    if(!isInitialized_) { return false; }
+
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, (address << 1) | I2C_MASTER_WRITE, true);
+
+    if(wBuff && len > 0) {
+        i2c_master_write(cmd, wBuff, len, true);
+    }
+
+    i2c_master_stop(cmd);
+    esp_err_t result = i2c_master_cmd_begin(port_, cmd, pdMS_TO_TICKS(1000));
+    i2c_cmd_link_delete(cmd);
+    return (result == ESP_OK);
+}
+
+/**
+* @brief Read the I2C data to the buffer
+* @param address I2C Address of the device
+* @param rBuff Data buffer to read into
+* @param len Length of data to read into `rBuff`. (defaults to 1 byte)
+* @return `true` if the read was successful, `false` otherwise
+*/
+bool cobalt::hal::I2CESPIDF::read(uint8_t address, uint8_t *rBuff, size_t len) {
+    if(!isInitialized_ || !rBuff) { return false; }
+
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, (address << 1) | I2C_MASTER_READ, true);
+
+    if(len > 1) {
+        i2c_master_read(cmd, rBuff, len-1, I2C_MASTER_ACK);
+    }
+    i2c_master_read_byte(cmd, rBuff + len-1, I2C_MASTER_NACK);
+
+    i2c_master_stop(cmd);
+    esp_err_t result = i2c_master_cmd_begin(port_, cmd, pdMS_TO_TICKS(1000));
+    i2c_cmd_link_delete(cmd);
+    return (result == ESP_OK);
+}
+
+/**
+* @brief Write to and then immediately read from the I2C device
+* @param address I2C Address of the device
+* @param wBuff Data buffer to read into
+* @param writeLen Length of `wBuff` to write.
+* @param rBuff Data buffer to read into
+* @param readLen Length of data to read into `rBuff`.
+* @return `true` if the write-read was successful, `false` otherwise
+*/
+bool cobalt::hal::I2CESPIDF::writeRead(uint8_t address, const uint8_t *wBuff, size_t writeLen, uint8_t *rBuff, size_t readLen) {
+    if(!isInitialized_) { return false; }
+
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+
+    i2c_master_write_byte(cmd, (address << 1) | I2C_MASTER_WRITE, true);
+
+    if(wBuff && writeLen > 0) {
+        i2c_master_write(cmd, wBuff, writeLen, true);
+    }
+
+    i2c_master_start(cmd);  // Mid-start
+
+    i2c_master_write_byte(cmd, (address << 1) | I2C_MASTER_READ, true);
+    if(readLen > 1) {
+        i2c_master_read(cmd, rBuff, readLen-1, I2C_MASTER_ACK);
+    }
+    i2c_master_read_byte(cmd, rBuff + readLen-1, I2C_MASTER_NACK);
+
+    i2c_master_stop(cmd);
+    esp_err_t result = i2c_master_cmd_begin(port_, cmd, pdMS_TO_TICKS(1000));
+    i2c_cmd_link_delete(cmd);
+    return (result == ESP_OK);
+}
+
+/**
+* @brief Write 1 byte to the I2C device's register from the buffer
+* @param address I2C Address of the device
+* @param regAddr I2C Device's register to read
+* @param wBuff Data buffer to write from
+* @return `true` if the register write was successful, `false` otherwise
+*/
+bool cobalt::hal::I2CESPIDF::writeReg(uint8_t address, uint8_t regAddr, uint8_t wBuff) {
+    uint8_t buff[2] = { regAddr, wBuff };
+    return write(address, buff, 2);
+}
+
+/**
+* @brief Read 1 byte from the I2C device's register to the buffer
+* @param address I2C Address of the device
+* @param regAddr I2C Device's register to read
+* @param rBuff Data buffer to read into
+* @return `true` if the register read was successful, `false` otherwise
+*/
+bool cobalt::hal::I2CESPIDF::readReg(uint8_t address, uint8_t regAddr, uint8_t *rBuff) {
+    uint8_t buff[1] = { regAddr };
+    if(!write(address, buff)) { return false; }
+    return read(address, rBuff);
+}
+#endif


### PR DESCRIPTION
### Overview
The PR introduces the initial implementation for the I²C HAL under `cobalt::hal` . The I²C HAL provides an abstraction layer when using the I²C protocol on Arduino & ESP32 boards which allows for portable code between them.

Two key implementations of I²C are implemented thus far:
**I2CArduino**, for abstraction in the Arduino framework
**I2CESPIDF**, for abstraction in the ESP-IDF framework

### Key Features
  * I2C Interface (`I2CBase`)
    - Initial I2C interface all others inherit from
    - Lightweight abstract class
  * Arduino Implementation (I2C Arduino)
    - Compatible with Arduino framework using Platform.io for C++17 & g++ compiler
    - Wrappers are included for `Wire.h` functions like `read()` & `write()`.
    - Supports multi or single byte read/write or writeRead requests as well as wrappers for register read/write
    - SDA and SCL pins are configurable if Arduino framework is on an ESP board, otherwise they should be left empty.
    - Adjustable Master/Slave mode and communication frequency
    - Bus-0 for Arduino and Bus-0 or Bus-1 for ESP boards available
  * ESP-IDF Implementation (I2CESPIDF)
    - Compatible with ESP-IDF framework using Platform.io for C++17 & g++ compiler
    - Wrappers are included for `driver/i2c.h`
    - Supports multi or single byte read/write or writeRead requests as well as wrappers for register read/write
    - Adjustable Master/Slave mode and communication frequency
    - Bus-0 or Bus-1 available
 * Platform/Framework specific type dispatcher
    - Select and use the correct I2C implementation as `cobalt::hal::I2C` automatically
   
### Tests 
- Manual sketch and platform.io tests give correct results for `read()`, `write()`, `writeRead()` as well as an I2C scanner implementation
  
### Notes
- Additional boards/frameworks will be supported in the future
- Slightly fixed how `hal.hpp` chooses between which abstraction to use