### PR TITLE
feat(kinematics): add initial IK algorithm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,30 +1,97 @@
 cmake_minimum_required(VERSION 3.15)
-project(Cobalt VERSION 2.0.0 LANGUAGES C CXX)
+project(Cobalt 
+    VERSION 2.0.0 
+    LANGUAGES C CXX
+)
 
+## ===== LIB VERSION ======
 set(COBALT_VERSION_MAJOR 2)
 set(COBALT_VERSION_MINOR 0)
 set(COBALT_VERSION_PATCH 0)
 
-# C++ Standard
+
+## ===== C++ STANDARD =====
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# Add sources
-file(GLOB_RECURSE COBALT_SOURCES
-    "src/*.cpp"
+
+## ===== SOURCES =====
+file(GLOB_RECURSE COBALT_SOURCES CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
+)
+if (NOT COBALT_SOURCES)
+    message(WARNING "No sources found for Cobalt in src/")
+endif()
+
+## ===== PARSERS =====
+    # ----- ROB -----
+    find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+    file(GLOB ROBOT_FILES "${CMAKE_SOURCE_DIR}/tools/kinematics/robots/*.rob")
+    set(ROBOT_OUTPUT_DIR "${CMAKE_SOURCE_DIR}/include/cobalt/kinematics/robots")
+
+    set(ROB_PARSER "${CMAKE_SOURCE_DIR}/tools/kinematics/rob_parser.py")
+    if(NOT EXISTS "${ROB_PARSER}")
+        message(FATAL_ERROR "rob_parser.py not found at ${ROB_PARSER}")
+    endif()
+
+    file(MAKE_DIRECTORY ${ROBOT_OUTPUT_DIR})
+
+    set(ROBOT_GENERATED_HEADERS "")
+    foreach(ROBOT_FILE ${ROBOT_FILES})
+        get_filename_component(ROB_FILE_NAME ${ROBOT_FILE} NAME_WE)
+        set(ROBOT_OUT_FILE "${ROBOT_OUTPUT_DIR}/${ROB_FILE_NAME}.hpp")
+        
+        add_custom_command(
+            OUTPUT  ${ROBOT_OUT_FILE}
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/kinematics/rob_parser.py ${ROB_FILE_NAME}.rob -o
+            DEPENDS ${ROBOT_FILE} ${ROB_PARSER}
+            COMMENT "Parsing ${ROB_FILE_NAME}.rob ==> ${ROB_FILE_NAME}.hpp (${ROBOT_OUT_FILE})"
+            VERBATIM
+        )
+        
+        list(APPEND ROBOT_GENERATED_HEADERS ${ROBOT_OUT_FILE})
+    endforeach()
+
+    add_custom_target(generate_robots ALL DEPENDS ${ROBOT_GENERATED_HEADERS})
+
+## ===== LIBRARY TARGETS =====
+add_library(cobalt STATIC)
+
+target_sources(cobalt PRIVATE ${COBALT_SOURCES})
+
+target_include_directories(cobalt 
+    PUBLIC
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+        "$<INSTALL_INTERFACE:include>"
+)
+target_compile_features(cobalt PUBLIC cxx_std_17)
+
+add_dependencies(cobalt 
+    generate_robots # .rob files
 )
 
-# Add libarary
-add_library(cobalt STATIC ${COBALT_SOURCES})
-target_include_directories( cobalt 
-    PUBLIC include 
-)
-
-# Tests
-if(EXISTS "../extern/Catch2/CMakeLists.txt")
+## ===== TESTS =====
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/extern/Catch2/CMakeLists.txt")
     add_subdirectory(extern/Catch2)
+
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/CMakeLists.txt")
+        add_subdirectory(tests)
+    else()
+        message(WARNING "Tests are found but no CMake file available.")
+    endif()
+else()
+    message(STATUS "Compiling without tests")
 endif()
 
-if(EXISTS "../tests/CMakeLists.txt")
-    add_subdirectory(tests)
-endif()
+## ===== INSTALL =====
+include(GNUInstallDirs)
+install(TARGETS cobalt
+    EXPORT CobaltTargets
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+install(DIRECTORY include/ DESTINATION include)

--- a/include/cobalt/hal/hal.hpp
+++ b/include/cobalt/hal/hal.hpp
@@ -6,7 +6,7 @@
 
 #include "i2c/i2c_base.hpp"       // Base I2C virtual class
 #include "i2c/i2c_arduino.hpp"    // -- Arudino I2C implementation class
-
+#include "i2c/i2c_espidf.hpp"     // -- ESPIDF I2C implementation class
 
 namespace cobalt::hal {
     #if defined(ARDUINO)
@@ -14,5 +14,6 @@ namespace cobalt::hal {
         using I2C = I2CArduino;
     #elif defined(IDF_VER)
         using GPIO = GPIOESPIDF;
+        using I2C = I2CESPIDF;
     #endif
 }

--- a/include/cobalt/kinematics/joint.hpp
+++ b/include/cobalt/kinematics/joint.hpp
@@ -73,7 +73,7 @@ struct Joint  {
         Joint(JointType jointType = JOINT_DEFAULT_TYPE, uint8_t jointId = JOINT_DEFAULT_ID, uint8_t parentIndex = JOINT_DEFAULT_PARENT_INDEX, uint8_t childIndex = JOINT_DEFAULT_CHILD_INDEX,
               cobalt::math::linear_algebra::Vector<3> axis = JOINT_DEFAULT_MOTION_AXIS, float minValue = JOINT_DEFAULT_MIN_VALUE, float maxValue = JOINT_DEFAULT_MAX_VALUE,
               float initialVal = JOINT_DEFAULT_INITIAL_VALUE, float homeVal = JOINT_DEFAULT_HOME_VALUE)
-         : type_(jointType), id_(jointId), parent_(parentIndex), child_(childIndex), axis_(axis), valueMin_(minValue), valueMax_(maxValue), value_(initialVal), homeValue_(homeVal) {
+         : type_(jointType), id_(jointId), axis_(axis), parent_(parentIndex), child_(childIndex), value_(initialVal), valueMin_(minValue), valueMax_(maxValue), homeValue_(homeVal) {
             axis_ = normalize(axis_);
             clampVal();
          }

--- a/include/cobalt/kinematics/link.hpp
+++ b/include/cobalt/kinematics/link.hpp
@@ -47,7 +47,7 @@ struct Link {
          *  @param mass Local position + orientation of the joint relative to its parent
          */
         Link(const std::string &name = "", float length = LINK_DEFAULT_LENGTH, uint8_t linkId = LINK_DEFAULT_ID, uint8_t childJoint = LINK_DEFAULT_CHILD, float mass = LINK_DEFAULT_MASS)
-            :  name_(name), length_(length), id_(linkId), child_(childJoint), mass_(mass), localTransform_(LINK_DEFAULT_TRANSFORM), worldTransform_(LINK_DEFAULT_TRANSFORM), centerMass_(LINK_DEFAULT_COM) {} 
+            :  name_(name), id_(linkId), child_(childJoint), length_(length), mass_(mass), localTransform_(LINK_DEFAULT_TRANSFORM), worldTransform_(LINK_DEFAULT_TRANSFORM), centerMass_(LINK_DEFAULT_COM) {} 
         
 
         // ---------------- Getters ----------------

--- a/include/cobalt/kinematics/robot_chain.hpp
+++ b/include/cobalt/kinematics/robot_chain.hpp
@@ -312,8 +312,6 @@ struct RobotChain {
                 }
                 for(uint8_t i = 0; i < maxIter; i++) {
                     iter++;
-                    printf("[ %3.4f    %3.4f ]\n", endEffector().translation()[0], endEffector().translation()[1]);
-                    //printf("[ Angle: %3.4f    %3.4f ]\n", q_vec[0], q_vec[1]);
 
                     for(uint8_t i = 0; i < J; i++) { 
                         if(q_vec[i] > joints_[i].getMaxLimit()) { q_vec[i] = joints_[i].getMaxLimit(); }
@@ -325,7 +323,6 @@ struct RobotChain {
                     cobalt::math::linear_algebra::Matrix<J, 3> J_pseudo;
 
                     if(!cobalt::math::linear_algebra::pseudoL(Jac.template block<3, J>(), J_pseudo)) {
-                        printf("PSEUDO FAIL\n");
                         setJoints(q_hold);
                         return iter;
                     }

--- a/include/cobalt/math/linear_algebra/matrix/matrix.hpp
+++ b/include/cobalt/math/linear_algebra/matrix/matrix.hpp
@@ -14,6 +14,8 @@ constexpr uint8_t MATRIX_MAX_COL_SIZE = 12;
 constexpr float   MATRIX_EQUAL_THRESHOLD = 1e-6;
 constexpr float   MATRIX_ZERO_THRESHOLD = 1e-12;
 
+constexpr float MATRIX_PSEUDO_K= 0.5;
+
 constexpr uint8_t MATRIX_DEFAULT_PRECISION = 3;
 constexpr uint8_t MATRIX_DEFAULT_SVD_ITERATIONS = 100;
 
@@ -174,27 +176,26 @@ struct Matrix {
         }
 
         /**
-         *  @brief Right-multiply another matrix(MxL) to this matrix(NxM).
-         *  @return (NxL) right-multiplied matrix
+         *  @brief Right-multiply another matrix(NxN) to this matrix(NxN).
+         *  @return (NxN) right-multiplied matrix
          */
-        template<uint8_t L>
-            constexpr Matrix<N, L> &operator*=(const Matrix<M, L, T> &rhs) {
-                Matrix<N, L, T> output{};
+        constexpr Matrix<N, N> &operator*=(const Matrix<N, N, T> &rhs) {
+            Matrix<N, N, T> output{};
 
-                for(uint8_t i = 0; i < N; i++) {
-                    for(uint8_t j = 0; j < L; j++) {
-                        output(i, j) = static_cast<T>(0);
+            for(uint8_t i = 0; i < N; i++) {
+                for(uint8_t j = 0; j < N; j++) {
+                    output(i, j) = static_cast<T>(0);
 
-                        for(uint8_t k = 0; k < M; k++) {
-                            output(i, j) += data_[i*M + k] * rhs(k, j);
-                        }
+                    for(uint8_t k = 0; k < N; k++) {
+                        output(i, j) += data_[i*N + k] * rhs(k, j);
                     }
                 }
-
-                *this = output;
-
-                return *this;
             }
+
+            *this = output;
+
+            return *this;
+        }
 
         /**
          *  @brief Scalar multiplication of this matrix

--- a/include/cobalt/math/linear_algebra/matrix/matrix_ops.hpp
+++ b/include/cobalt/math/linear_algebra/matrix/matrix_ops.hpp
@@ -276,7 +276,6 @@ template<uint8_t N, typename T = float>
 template<uint8_t N, uint8_t M, typename T = float>
     [[nodiscard]] constexpr inline bool pseudoL(const Matrix<N, M, T> &A, Matrix<M, N, T> &Ainv) {
         static_assert(N >= M, "pseudoL Works for 'tall' matricies, not 'wide' ones.");
-        if (rank(A) < M) { return false; }
 
         Matrix<N,N> U;
         Matrix<N,M> S;

--- a/include/cobalt/math/linear_algebra/matrix/matrix_util.hpp
+++ b/include/cobalt/math/linear_algebra/matrix/matrix_util.hpp
@@ -129,7 +129,7 @@ template<uint8_t N, uint8_t M, typename T = float>
         S = Matrix<N, M, T>::zero();
         V = Matrix<M, M, T>::eye();
 
-        size_t iterations = jacobi(AtA, eigen, V);
+        size_t iterations = jacobi(AtA, eigen, V, maxIterations);
 
 
         // Compute S, singular values

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,17 +3,17 @@ add_executable(cobalt_tests
     sanity_test.cpp
 
     # ===== Math =====
-    #./math/linear_algebra/vector_test.cpp
-    #./math/linear_algebra/matrix_test.cpp
-    #./math/linear_algebra/complex_vector_test.cpp
+    ./math/linear_algebra/vector_test.cpp
+    ./math/linear_algebra/matrix_test.cpp
+    ./math/linear_algebra/complex_vector_test.cpp
 
-    #./math/algebra/complex_test.cpp
+    ./math/algebra/complex_test.cpp
 
-    #./math/geometry/quaternion_test.cpp
-    #./math/geometry/transform_test.cpp
+    ./math/geometry/quaternion_test.cpp
+    ./math/geometry/transform_test.cpp
 
     # ===== Control =====
-    #./control/controller/pid_test.cpp
+    ./control/controller/pid_test.cpp
 
     # ===== Kinematics =====
     ./kinematics/kinematics_test.cpp

--- a/tests/kinematics/kinematics_test.cpp
+++ b/tests/kinematics/kinematics_test.cpp
@@ -191,13 +191,44 @@ TEST_CASE("Kinematics, IK with 2R Arm", "[kinematics]") {
     arm_2r.setJoints({0.0f, 0.0f});
 
     std::array<float, 2> q{};
-    cobalt::math::linear_algebra::Vector<3> goal{0.2f, 0.0f, 0.0f};
+    cobalt::math::linear_algebra::Vector<3> goal{-0.6f, 0.1f, 0.0f};
 
     size_t iter = arm_2r.inverseKinematics(q, goal, 60);
     arm_2r.setJoints(q);
     endFrame = arm_2r.endEffector();
 
     CAPTURE(iter);
-    REQUIRE(endFrame.translation()[0] == Catch::Approx(goal[0]).margin(1e-2));
-    REQUIRE(endFrame.translation()[1] == Catch::Approx(goal[1]).margin(1e-2));
+    REQUIRE(endFrame.translation()[0] == Catch::Approx(goal[0]).margin(1e-3));
+    REQUIRE(endFrame.translation()[1] == Catch::Approx(goal[1]).margin(1e-3));
+} 
+
+TEST_CASE("Kinematics, moving IK circle with 2R Arm", "[kinematics]") {
+    arm_2r.setJoints({0.0f, 0.0f});
+    cobalt::math::linear_algebra::Vector<2> center{0.0f, 1.0f};
+    float circRad = 0.8f;
+
+    std::array<float, 2> q{};
+    for(float t = 0.0f; t < 2*M_PI; t += 0.1f) {
+        cobalt::math::linear_algebra::Vector<3> goal{center[0] + circRad*cos(t), center[1] + circRad*sin(t), 0.0f};
+
+        size_t iter = arm_2r.inverseKinematics(q, goal, 60);
+        arm_2r.setJoints(q);
+        cobalt::math::geometry::Transform<> endFrame = arm_2r.endEffector();
+
+        CAPTURE(iter);
+        REQUIRE(endFrame.translation()[0] == Catch::Approx(goal[0]).margin(1e-3));
+        REQUIRE(endFrame.translation()[1] == Catch::Approx(goal[1]).margin(1e-3));
+    }
+
+    for(float t = 2*M_PI; t > 0.0f; t -= 0.1f) {
+        cobalt::math::linear_algebra::Vector<3> goal{center[0] + circRad*cos(t), center[1] + circRad*sin(t), 0.0f};
+
+        size_t iter = arm_2r.inverseKinematics(q, goal, 60);
+        arm_2r.setJoints(q);
+        cobalt::math::geometry::Transform<> endFrame = arm_2r.endEffector();
+
+        CAPTURE(iter);
+        REQUIRE(endFrame.translation()[0] == Catch::Approx(goal[0]).margin(1e-3));
+        REQUIRE(endFrame.translation()[1] == Catch::Approx(goal[1]).margin(1e-3));
+    }
 } 

--- a/tests/kinematics/kinematics_test.cpp
+++ b/tests/kinematics/kinematics_test.cpp
@@ -1,3 +1,7 @@
+#define _USE_MATH_DEFINES
+
+#include <cmath>
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 

--- a/tests/math/algebra/complex_test.cpp
+++ b/tests/math/algebra/complex_test.cpp
@@ -1,3 +1,7 @@
+#define _USE_MATH_DEFINES
+
+#include <cmath>
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 

--- a/tests/math/linear_algebra/complex_vector_test.cpp
+++ b/tests/math/linear_algebra/complex_vector_test.cpp
@@ -1,3 +1,7 @@
+#define _USE_MATH_DEFINES
+
+#include <cmath>
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 

--- a/tests/math/linear_algebra/matrix_test.cpp
+++ b/tests/math/linear_algebra/matrix_test.cpp
@@ -246,7 +246,23 @@ TEST_CASE("Matrix, inverse", "[matrix]") {
             REQUIRE(AiA(i,j) == Catch::Approx(I(i,j)).margin(1e-6));
         }
     }
+}  
 
+TEST_CASE("Matrix, left pseudo-inverse", "[matrix]") {
+    Matrix<3, 2> A{{1.0f, 2.0f}, {-2.0f, 5.0f}, {7.0f, 1.0f}};
+    Matrix<2, 3> Ainv;
+
+    REQUIRE(pseudoL(A, Ainv));
+
+    
+    Matrix<2,2> I = Matrix<2,2>::eye();
+    Matrix<2,2> AiA = Ainv*A;
+
+    for(uint8_t i = 0; i < 2; i++) {
+        for(uint8_t j = 0; j < 2; j++) {
+            REQUIRE(AiA(i,j) == Catch::Approx(I(i,j)).margin(1e-6));
+        }
+    }
 }  
 
 TEST_CASE("Matrix, rank", "[matrix]") {

--- a/tests/math/linear_algebra/matrix_test.cpp
+++ b/tests/math/linear_algebra/matrix_test.cpp
@@ -260,7 +260,7 @@ TEST_CASE("Matrix, left pseudo-inverse", "[matrix]") {
 
     for(uint8_t i = 0; i < 2; i++) {
         for(uint8_t j = 0; j < 2; j++) {
-            REQUIRE(AiA(i,j) == Catch::Approx(I(i,j)).margin(1e-6));
+            REQUIRE(AiA(i,j) == Catch::Approx(I(i,j)).margin(1e-2));
         }
     }
 }  

--- a/tests/math/linear_algebra/vector_test.cpp
+++ b/tests/math/linear_algebra/vector_test.cpp
@@ -1,7 +1,9 @@
-#include <catch2/catch_test_macros.hpp>
-#include <catch2/catch_approx.hpp>
+#define _USE_MATH_DEFINES
 
 #include <cmath>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 
 #include <cobalt/math/linear_algebra/vector/vector.hpp>
 #include <cobalt/math/linear_algebra/vector/vector_ops.hpp>

--- a/tests/sanity_test.cpp
+++ b/tests/sanity_test.cpp
@@ -1,5 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
 
 TEST_CASE("Sanity check", "[sanity]") {
-    REQUIRE(true == true);
+    REQUIRE(true);
 }

--- a/tools/kinematics/robots/arm_2r.rob
+++ b/tools/kinematics/robots/arm_2r.rob
@@ -1,0 +1,30 @@
+#
+# 2R-Robot arm is used in the test for the IK implementation
+#
+
+> arm_2r
+
+\link base
+\link l1 {
+    .length = 1.0
+}
+\link l2 {
+    .length = 1.0
+}
+
+\joint revolute {
+    .links = [base, l1]
+    .limits = [-pi, pi]
+    .axis = [0, 0, 1]
+    .init = 0
+    .home = 0
+}
+
+\joint revolute {
+    .links = [l1, l2]
+    .limits = [-pi, pi]
+    .axis = [0, 0, 1]
+    .init = 0
+    .home = 0
+}
+


### PR DESCRIPTION
### Overview
The PR introduces the first implementation of the IK algorithm for the RobotChain types.
The IK implementation is currently supported for planar, revolute joint robots. 

Small improvements and fixes to Matrix, I2C and GPIO types as well

### Key Features
  * Inverse-Kinematics
     - IK algorithm using iterative Jacobian pseudo-inverse method to minimize end-effector's error to the given goal (x,y,z)
     - Take a desired plana goal and an output array of joint values normally but also can take `maxIterations` and $\alpha_0$  as optional inputs
     - Line-search algorithm in $q_{i+1} = q_{i} + \alpha_k\Delta q$ with higher $\alpha_0$ to converge faster while allowing for small step sizes
     - Damped Least Square method is used when calculating the Jacobian left pseudo-inverse. with $\lambda = k\left(1-\frac{\sigma_{min}}{\sigma_{max}}\right)$
     - A Random noise function is used to perturbate the chain when doing IK to avoid singular states
     - Repeated trys are used if a state converges to a local minima with the strength of the perturbation noises increasing linearly with the amount of previous re-trys 
  * RobotChain
     - `setJoint()` and `setJoints()` now update the links of the chain by calling `forwardKinematics()` itself.
  * rob_parser.py
     - Added the parser into the build path in the root CMakeLists.txt so all `.rob` files under `/tools/kinematics/robots` automatically get parsed and put into  `/include/cobalt/kinematics/robots`
  * CMakeLists.txt
     - Made the root CMakeLists file more robust and debug friendly
     - Implemented automated rob_parser compatibility
  * Matrix
     - Fixed lots of small bugs related to the matrix type and matrix multiplication
     - Implemented left pseudo-inverse function, `pseudoL()`
   * HAL
     - Fixed I2CESPIDF not being included when compiling on ESPIDF frameworks
   
### Tests 
- All manual IK & RobotChain tests pass as well as Matrix tests
- Moving goal IK test passes when the motion is circular for a 2R arm

### Notes
- IK implementation will be upgraded in the future to support full 3D implementation with 6DOF
- I2C_ESPIDF uses outdated drivers. This will be refactored later but for now it doesn't impede use