### PR TITLE
feat(hal): Add initial I2C abstraction for Arduino and ESP-IDF frameworks

### DIFF
--- a/include/cobalt/hal/gpio/gpio_arduino.hpp
+++ b/include/cobalt/hal/gpio/gpio_arduino.hpp
@@ -2,7 +2,7 @@
 
 #include "gpio_base.hpp"
 
-#if ARDUINO
+#if defined(ARDUINO_ARCH_ESP32)
 #include <Arduino.h>
 
 namespace cobalt::hal {

--- a/include/cobalt/hal/gpio/gpio_espidf.hpp
+++ b/include/cobalt/hal/gpio/gpio_espidf.hpp
@@ -4,7 +4,7 @@
 
 #include "gpio_base.hpp"
 
-#ifdef IDF_VER
+#if (defined(ESP_PLATFORM) && !defined(ARDUINO_ARCH_ESP32))
 #include <driver/gpio.h>
 #include <driver/ledc.h>
 

--- a/include/cobalt/hal/hal.hpp
+++ b/include/cobalt/hal/hal.hpp
@@ -8,11 +8,13 @@
 #include "i2c/i2c_arduino.hpp"    // -- Arudino I2C implementation class
 #include "i2c/i2c_espidf.hpp"     // -- ESPIDF I2C implementation class
 
+#include "timer/timer.hpp"          // Base Timer implementation
+
 namespace cobalt::hal {
-    #if defined(ARDUINO)
+    #if defined(ARDUINO_ARCH_ESP32)
         using GPIO = GPIOArduino;
         using I2C = I2CArduino;
-    #elif defined(IDF_VER)
+    #elif defined(ESP_PLATFORM)
         using GPIO = GPIOESPIDF;
         using I2C = I2CESPIDF;
     #endif

--- a/include/cobalt/hal/i2c/i2c_arduino.hpp
+++ b/include/cobalt/hal/i2c/i2c_arduino.hpp
@@ -4,7 +4,7 @@
 
 #include "i2c_base.hpp"
 
-#if defined(ARDUINO)
+#if defined(ARDUINO_ARCH_ESP32)
 #include <Wire.h>
 
 namespace cobalt::hal {

--- a/include/cobalt/hal/i2c/i2c_espidf.hpp
+++ b/include/cobalt/hal/i2c/i2c_espidf.hpp
@@ -6,7 +6,7 @@
 
 #include "i2c_base.hpp"
 
-#if defined(IDF_VER)
+#if (defined(IDF_VER) && !defined(ARDUINO_ARCH_ESP32))
 #include <driver/i2c.h>
 
 namespace cobalt::hal {

--- a/include/cobalt/hal/timer/timer.hpp
+++ b/include/cobalt/hal/timer/timer.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace cobalt::hal {
+    // --------------------------------------
+    //      Base Timer Implementation    
+    // --------------------------------------
+
+    static unsigned long timeStamp = 0;
+
+    // ---------------- Timer Functions ----------------
+
+    /**
+     * @brief Sleep the program for `millis` ms
+     * @param millis Amount of time in ms to sleep
+     */
+    void wait(uint32_t millis);
+
+    /**
+     * @brief Get current time (ms)
+     * @return Amount of time elapsed since the start of execution in ms
+     */
+    unsigned long elapsed();
+    /**
+     * @brief Get current time (μs)
+     * @return Amount of time elapsed since the start of execution in μs
+     */
+    unsigned long elapsedUs();
+
+    /**
+     * @brief Set the timerStamp to the current elapsed time. 
+     * 
+     * Use `checkStamp()` later to calculate amount of time passed
+     */
+    void setStamp();
+    /**
+     * @brief Check the amount of time passed since the timeStamp placement
+     * @return Amount of time elapsed since the `timeStamp` was placed in μs
+     */
+    unsigned long checkStamp();
+    
+} //cobalt::hal

--- a/include/cobalt/util/meta/build_info.hpp
+++ b/include/cobalt/util/meta/build_info.hpp
@@ -8,12 +8,12 @@ struct BuildInfo {
     /**
      *  @brief Date of latest compilation
      */
-    static constexpr char* COMPILE_DATE = (char* const)__DATE__;
+    static constexpr char* COMPILE_DATE = __DATE__;
 
     /**
      *  @brief Time of latest compilation
      */
-    static constexpr char* COMPILE_TIME = (char* const)__TIME__;
+    static constexpr char* COMPILE_TIME = __TIME__;
 
     /**
      *  @brief C++ standard of the library

--- a/src/hal/gpio/gpio_arduino.cpp
+++ b/src/hal/gpio/gpio_arduino.cpp
@@ -1,7 +1,6 @@
 #include "cobalt/hal/gpio/gpio_arduino.hpp"
 
-#if ARDUINO
-#include <Arduino.h>
+#if defined(ARDUINO_ARCH_ESP32)
 
 /**
 * @brief Set the GPIO pins mode/type

--- a/src/hal/gpio/gpio_espidf.cpp
+++ b/src/hal/gpio/gpio_espidf.cpp
@@ -1,6 +1,6 @@
 #include "cobalt/hal/gpio/gpio_espidf.hpp"
 
-#ifdef IDF_VER
+#if (defined(IDF_VER) && !defined(ARDUINO_ARCH_ESP32))
 
 // ---------------- ESPIDF GPIO Private Helper Functions ----------------
 /**

--- a/src/hal/i2c/i2c_arduino.cpp
+++ b/src/hal/i2c/i2c_arduino.cpp
@@ -1,7 +1,6 @@
 #include "cobalt/hal/i2c/i2c_arduino.hpp"
 
-
-#if defined(ARDUINO)
+#if defined(ARDUINO_ARCH_ESP32)
 
 /**
 * @brief Initialize to start communication with the I2C Interface

--- a/src/hal/i2c/i2c_espidf.cpp
+++ b/src/hal/i2c/i2c_espidf.cpp
@@ -1,6 +1,6 @@
 #include "cobalt/hal/i2c/i2c_espidf.hpp"
 
-#if defined(IDF_VER)
+#if (defined(IDF_VER) && !defined(ARDUINO_ARCH_ESP32))
 
 /**
 * @brief Initialize to start communication with the I2C Interface

--- a/src/hal/timer/timer_arduino.cpp
+++ b/src/hal/timer/timer_arduino.cpp
@@ -1,0 +1,26 @@
+#include "cobalt/hal/timer/timer.hpp"
+
+#if defined(ARDUINO_ARCH_ESP32)
+
+#include <Arduino.h>
+
+void cobalt::hal::wait(uint32_t millis) {
+    delay(millis);
+}
+
+unsigned long cobalt::hal::elapsed() {
+    return millis();
+}
+
+unsigned long cobalt::hal::elapsedUs() {
+    return micros();
+}
+
+void cobalt::hal::setStamp() {
+    cobalt::hal::timeStamp = elapsedUs();
+}
+unsigned long cobalt::hal::checkStamp() {
+    return (elapsedUs() - cobalt::hal::timeStamp);
+}
+
+#endif

--- a/src/hal/timer/timer_espidf.cpp
+++ b/src/hal/timer/timer_espidf.cpp
@@ -1,0 +1,26 @@
+#include "cobalt/hal/timer/timer.hpp"
+
+#if (defined(IDF_VER) && !defined(ARDUINO_ARCH_ESP32))
+
+#include <esp_timer.h>
+
+void cobalt::hal::wait(uint32_t millis) {
+    vTaskDelay(millis / portTICK_RATE_MS);
+}
+
+unsigned long cobalt::hal::elapsed() {
+    return esp_timer_get_time() / 1000;
+}
+
+unsigned long cobalt::hal::elapsedUs() {
+    return esp_timer_get_time();
+}
+
+void cobalt::hal::setStamp() {
+    cobalt::hal::timeStamp = elapsedUs();
+}
+unsigned long cobalt::hal::checkStamp() {
+    return (elapsedUs() - cobalt::hal::timeStamp);
+}
+
+#endif


### PR DESCRIPTION
### Overview
The PR introduces the initial implementation for the Timer HAL under `cobalt::hal` . The HAL provides an abstraction layer when using the timer implementation

Two key implementations of the Timer are implemented thus far:
**timer_arduino**, for abstraction in the Arduino framework
**timer_espdif**, for abstraction in the ESP-IDF framework

The timer HAL is classless so only the function implementations change between different frameworks

### Key Features
  * Timer
     - General purpose thread sleeping, `wait()`
     - Recover total elapsed time since execution start, `elapsed()` & `elapsedUs()`
     - Set and check the time since a timestamp in μs, `setStamp()` & `checkStamp()`
   
### Tests 
- Manual timing tests get a timer as accurate as 100μs-10μs on an ESP32-Dev board
  
### Notes
- Additional boards/frameworks will be supported in the future